### PR TITLE
docs: generate documentation with TypeDoc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,5 +45,12 @@ jobs:
       - name: Build package
         run: npm run build
 
-      - name: Codecov
-        uses: codecov/codecov-action@v3
+      - name: Build docs
+        run: npm run docs
+
+      - name: Deploy
+        if: github.ref == 'refs/heads/master'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: docs

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ jspm_packages
 .node_repl_history
 
 # Build files
+docs/
 lib/
 
 # Vim swap files

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ require('cypress-cucumber-steps');
 
 The step definition can be used in the feature file:
 
-```feature
+```gherkin
 # cypress/e2e/example.feature
 When I visit "https://example.com/"
 ```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf lib",
+    "clean": "rm -rf docs lib",
+    "docs": "typedoc",
+    "docs:watch": "typedoc --watch",
     "lint": "eslint --ignore-path .gitignore --ext .js,.ts .",
     "lint:fix": "npm run lint -- --fix",
     "lint:tsc": "tsc --noEmit",
@@ -49,6 +51,7 @@
     "lint-staged": "13.0.4",
     "pinst": "3.0.0",
     "prettier": "2.8.0",
+    "typedoc": "0.23.21",
     "typescript": "4.9.3"
   },
   "peerDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,40 @@
 import { When } from '@badeball/cypress-cucumber-preprocessor';
 
-When('I visit {string}', (url: string) => {
+/* eslint-disable tsdoc/syntax */
+/**
+ * When I visit URL:
+ *
+ * ```gherkin
+ * When I visit {string}
+ * ```
+ *
+ * @example
+ *
+ * With absolute URL:
+ *
+ * ```gherkin
+ * When I visit "https://example.com/"
+ * ```
+ *
+ * With relative URL:
+ *
+ * ```gherkin
+ * When I visit "/"
+ * ```
+ *
+ * > Cypress `baseUrl` must be configured.
+ *
+ * @remarks
+ *
+ * This will fail if the page does not respond with a 200 status code:
+ *
+ * ```gherkin
+ * When I visit "/404" # fail
+ * ```
+ */
+/* eslint-enable tsdoc/syntax */
+export function When_I_visit_URL(url: string) {
   cy.visit(url);
-});
+}
+
+When('I visit {string}', When_I_visit_URL);

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "entryPoints": ["src"]
+}


### PR DESCRIPTION
## What is the motivation for this pull request?

docs: generate documentation with [TypeDoc](https://github.com/TypeStrong/typedoc)

## What is the current behavior?

No docs

## What is the new behavior?

Docs

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [x] Documentation