### PR TITLE
build(package): upgrade devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,14 @@
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
-        "@badeball/cypress-cucumber-preprocessor": "14.0.0",
+        "@badeball/cypress-cucumber-preprocessor": "15.0.0",
         "@bahmutov/cypress-esbuild-preprocessor": "2.1.5",
         "@commitlint/cli": "17.3.0",
         "@commitlint/config-conventional": "17.3.0",
         "@types/node": "18.11.11",
         "@typescript-eslint/eslint-plugin": "5.45.1",
         "@typescript-eslint/parser": "5.45.1",
-        "cypress": "11.2.0",
+        "cypress": "12.0.1",
         "eslint": "8.29.0",
         "eslint-plugin-prettier": "4.2.1",
         "eslint-plugin-simple-import-sort": "8.0.0",
@@ -25,7 +25,7 @@
         "husky": "8.0.2",
         "lint-staged": "13.1.0",
         "pinst": "3.0.0",
-        "prettier": "2.8.0",
+        "prettier": "2.8.1",
         "typedoc": "0.23.21",
         "typescript": "4.9.3"
       },
@@ -158,9 +158,9 @@
       }
     },
     "node_modules/@badeball/cypress-cucumber-preprocessor": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@badeball/cypress-cucumber-preprocessor/-/cypress-cucumber-preprocessor-14.0.0.tgz",
-      "integrity": "sha512-6biPTAhfnyAB/n3lv+jz1jJyC8/oqAF0v7FavttDYPpQiGnzO/C0vK0qdApwmXPzCIyeqTNlAyIflb9aSKrIiA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@badeball/cypress-cucumber-preprocessor/-/cypress-cucumber-preprocessor-15.0.0.tgz",
+      "integrity": "sha512-C+n9ScTtK8kZv1dbVYacXLKpjMt4Ws8+r68BZuUPhJ73CElnaHwvlHpXHq9xwyx/NPjttL2Mpy/o6mAEpJJIKA==",
       "dev": true,
       "dependencies": {
         "@badeball/cypress-configuration": "^4.0.0",
@@ -194,7 +194,7 @@
       },
       "peerDependencies": {
         "@cypress/browserify-preprocessor": "^3.0.1",
-        "cypress": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+        "cypress": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
       },
       "peerDependenciesMeta": {
         "@cypress/browserify-preprocessor": {
@@ -1868,9 +1868,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.0.1.tgz",
+      "integrity": "sha512-I1Ag5RsPEINfUlQtV6xwkd6ktJuu5QGiKZ3pFa/IXjcyCY6I7CH3gOz0juLOhg/LXOPrQtZH35ulcWDQohyyEA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1921,7 +1921,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
@@ -4940,9 +4940,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
-      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -6215,9 +6215,9 @@
       }
     },
     "@badeball/cypress-cucumber-preprocessor": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@badeball/cypress-cucumber-preprocessor/-/cypress-cucumber-preprocessor-14.0.0.tgz",
-      "integrity": "sha512-6biPTAhfnyAB/n3lv+jz1jJyC8/oqAF0v7FavttDYPpQiGnzO/C0vK0qdApwmXPzCIyeqTNlAyIflb9aSKrIiA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@badeball/cypress-cucumber-preprocessor/-/cypress-cucumber-preprocessor-15.0.0.tgz",
+      "integrity": "sha512-C+n9ScTtK8kZv1dbVYacXLKpjMt4Ws8+r68BZuUPhJ73CElnaHwvlHpXHq9xwyx/NPjttL2Mpy/o6mAEpJJIKA==",
       "dev": true,
       "requires": {
         "@badeball/cypress-configuration": "^4.0.0",
@@ -7485,9 +7485,9 @@
       }
     },
     "cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.0.1.tgz",
+      "integrity": "sha512-I1Ag5RsPEINfUlQtV6xwkd6ktJuu5QGiKZ3pFa/IXjcyCY6I7CH3gOz0juLOhg/LXOPrQtZH35ulcWDQohyyEA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -9650,9 +9650,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
-      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -37,14 +37,14 @@
     "test"
   ],
   "devDependencies": {
-    "@badeball/cypress-cucumber-preprocessor": "14.0.0",
+    "@badeball/cypress-cucumber-preprocessor": "15.0.0",
     "@bahmutov/cypress-esbuild-preprocessor": "2.1.5",
     "@commitlint/cli": "17.3.0",
     "@commitlint/config-conventional": "17.3.0",
     "@types/node": "18.11.11",
     "@typescript-eslint/eslint-plugin": "5.45.1",
     "@typescript-eslint/parser": "5.45.1",
-    "cypress": "11.2.0",
+    "cypress": "12.0.1",
     "eslint": "8.29.0",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-simple-import-sort": "8.0.0",
@@ -52,7 +52,7 @@
     "husky": "8.0.2",
     "lint-staged": "13.1.0",
     "pinst": "3.0.0",
-    "prettier": "2.8.0",
+    "prettier": "2.8.1",
     "typedoc": "0.23.21",
     "typescript": "4.9.3"
   },


### PR DESCRIPTION
Closes #15

## What is the motivation for this pull request?

build(package): upgrade devDependencies

```
 @badeball/cypress-cucumber-preprocessor  14.0.0  →  15.0.0
 cypress                                  11.2.0  →  12.0.1
 prettier                                  2.8.0  →   2.8.1
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation