### PR TITLE
build(tsconfig): target es6 for test and es5 for build

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,6 +1,0 @@
-{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "target": "es6"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Mark <mark@remarkablemark.org>",
   "main": "lib/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --target es5",
     "clean": "rm -rf docs lib",
     "cypress:open": "cypress open",
     "docs": "typedoc",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "lib": ["es5", "dom"],
     "declaration": true,


### PR DESCRIPTION
## What is the motivation for this pull request?

build(tsconfig): target es6 for test and es5 for build

Fix esbuild error when running Cypress:

```
ERROR: Transforming const to the configured target environment ("es5") is not supported yet
```

## What is the current behavior?

Cypress (test) build targets es5

## What is the new behavior?

Cypress (test) build targets es6

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation