### PR TITLE
feat: add query "When I get element by label text" and action "When I type"

### DIFF
--- a/cypress/e2e/cypress/cypress.feature
+++ b/cypress/e2e/cypress/cypress.feature
@@ -5,3 +5,6 @@ Feature: Cypress
       And I do not see text "cy.get()"
     When I click on text "get"
     Then I see text "cy.get()"
+    When I visit "https://example.cypress.io/commands/actions"
+      And I get element by label text "Email address"
+      And I type "user@example.com"

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,4 +1,5 @@
 export * from './click';
 export * from './reload';
+export * from './type';
 export * from './visit';
 export * from './wait';

--- a/src/actions/type.ts
+++ b/src/actions/type.ts
@@ -1,0 +1,31 @@
+import { When } from '@badeball/cypress-cucumber-preprocessor';
+
+import { getCypressElement } from '../utils';
+
+/**
+ * When I type:
+ *
+ * ```gherkin
+ * When I type {string}
+ * ```
+ *
+ * @example
+ *
+ * ```gherkin
+ * When I type "Hello, world!"
+ * ```
+ *
+ * @remarks
+ *
+ * This requires a preceding step like query {@link When_I_get_element_by_label_text | "When I get element by label text"}. E.g.:
+ *
+ * ```gherkin
+ * When I get element by label text "Email"
+ *   And I type "user@example.com"
+ * ```
+ */
+export function When_I_type(text: string) {
+  getCypressElement(this).type(text);
+}
+
+When('I type {string}', When_I_type);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './actions';
 export * from './assertions';
+export * from './utils';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './actions';
 export * from './assertions';
+export * from './queries';
 export * from './utils';

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,0 +1,1 @@
+export * from './label';

--- a/src/queries/label.ts
+++ b/src/queries/label.ts
@@ -1,0 +1,51 @@
+import { When } from '@badeball/cypress-cucumber-preprocessor';
+
+import { setCypressElement } from '../utils';
+
+/* eslint-disable tsdoc/syntax */
+/**
+ * When I get element by label text:
+ *
+ * ```gherkin
+ * When I get element by label text {string}
+ * ```
+ *
+ * > This query will throw an error if no element is found not will not wait and retry.
+ *
+ * @example
+ *
+ * ```gherkin
+ * When I get element by label text "Email"
+ * ```
+ *
+ * @remarks
+ *
+ * This is a preceding step for actions like {@link When_I_type | "When I type"}. E.g.:
+ *
+ * ```gherkin
+ * When I get element by label text "Email"
+ *   And I type "user@example.com"
+ * ```
+ *
+ * Inspired by Testing Library's [ByLabelText](https://testing-library.com/docs/queries/bylabeltext).
+ */
+/* eslint-enable tsdoc/syntax */
+export function When_I_get_element_by_label_text(text: string) {
+  cy.get('body').then(($body) => {
+    let cypressElement;
+
+    if ($body.find('label').text().includes(text)) {
+      cypressElement = cy.get('label').contains(text);
+    } else if ($body.find(`[aria-labelledby='${text}']`).length) {
+      cypressElement = cy.get(`[aria-labelledby='${text}']`);
+    } else if ($body.find(`[aria-label='${text}']`).length) {
+      cypressElement = cy.get(`[aria-label='${text}']`);
+    } else {
+      throw new Error(`Unable to get a label with the text of: ${text}`);
+    }
+
+    setCypressElement(this, cypressElement);
+  });
+}
+
+When('I get element by label text {string}', When_I_get_element_by_label_text);

--- a/src/utils/element.ts
+++ b/src/utils/element.ts
@@ -1,0 +1,49 @@
+/* eslint-disable tsdoc/syntax */
+
+/**
+ * @private
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type CypressChainableElement = Cypress.Chainable<any>;
+
+/**
+ * @private
+ */
+export interface MochaContext extends Mocha.Context {
+  cypressElement?: CypressChainableElement;
+}
+
+/**
+ * Set Cypress element on Mocha Context.
+ *
+ * @private
+ *
+ * @param context - Mocha context.
+ * @param element - Cypress element.
+ */
+export function setCypressElement(
+  context: MochaContext,
+  element: CypressChainableElement
+) {
+  context.cypressElement = element;
+}
+
+/**
+ * Get Cypress element from Mocha Context.
+ *
+ * @private
+ *
+ * @param context - Mocha context.
+ * @returns - Cypress element.
+ */
+export function getCypressElement(context: MochaContext) {
+  if (!Cypress.isCy(context.cypressElement)) {
+    throw new Error(
+      `The element you are chaining off is ${context.cypressElement}.
+
+Add a preceding step "When I get element by ..." or "When I find element by ..."`
+    );
+  }
+
+  return context.cypressElement;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './element';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "strict": true,
     "outDir": "lib",
     "skipLibCheck": true,
-    "types": ["cypress", "node"]
+    "types": ["cypress", "node"],
+    "noImplicitThis": false
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add query "When I get element by label text" and action "When I type"

## What is the current behavior?

No query "When I get element by label text" and action "When I type"

## What is the new behavior?

Query "When I get element by label text" and action "When I type"

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation