### PR TITLE
fix(assertions): assert "Then I see text" is also visible

### DIFF
--- a/src/assertions/text.ts
+++ b/src/assertions/text.ts
@@ -12,9 +12,13 @@ import { Then } from '@badeball/cypress-cucumber-preprocessor';
  * ```gherkin
  * Then I see text "Hello, world!"
  * ```
+ *
+ * @remarks
+ *
+ * This asserts that the text _exists_ and is _visible_ in the screen.
  */
 export function Then_I_see_text(text: string) {
-  cy.contains(text).should('exist');
+  cy.contains(text).should('exist').and('be.visible');
 }
 
 Then('I see text {string}', Then_I_see_text);
@@ -29,8 +33,12 @@ Then('I see text {string}', Then_I_see_text);
  * @example
  *
  * ```gherkin
- * Then I do not see text "Hello, world!"
+ * Then I do not see text "I do not exist"
  * ```
+ *
+ * @remarks
+ *
+ * This asserts that the text _does not exist_ in the screen.
  */
 export function Then_I_do_not_see_text(text: string) {
   cy.contains(text).should('not.exist');


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(assertions): assert "Then I see text" is also visible

## What is the current behavior?

`Then I see text` only asserts that text exists

## What is the new behavior?

`Then I see text` only asserts that text exists and is visible

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [x] Documentation