### PR TITLE
fix(queries): return 1st element in "When I get element by label text"

### DIFF
--- a/src/queries/label.ts
+++ b/src/queries/label.ts
@@ -35,11 +35,11 @@ export function When_I_get_element_by_label_text(text: string) {
     let cypressElement;
 
     if ($body.find('label').text().includes(text)) {
-      cypressElement = cy.get('label').contains(text);
+      cypressElement = cy.contains('label', text);
     } else if ($body.find(`[aria-labelledby='${text}']`).length) {
-      cypressElement = cy.get(`[aria-labelledby='${text}']`);
+      cypressElement = cy.get(`[aria-labelledby='${text}']`).first();
     } else if ($body.find(`[aria-label='${text}']`).length) {
-      cypressElement = cy.get(`[aria-label='${text}']`);
+      cypressElement = cy.get(`[aria-label='${text}']`).first();
     } else {
       throw new Error(`Unable to get element by label text: ${text}`);
     }


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(queries): return 1st element in "When I get element by label text"

## What is the current behavior?

Multiple elements can be returned from "When I get element by label text"

## What is the new behavior?

The first element is returned from "When I get element by label text"

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation