### PR TITLE
fix(queries): get input and textarea by display value and not default value

### DIFF
--- a/src/actions/value.ts
+++ b/src/actions/value.ts
@@ -25,7 +25,9 @@ import { getCypressElement } from '../utils';
  * ```
  */
 export function When_I_set_value(value: string) {
-  getCypressElement(this).invoke('val', value).trigger('change');
+  getCypressElement(this)
+    .then((element) => Cypress.$(element).val(value))
+    .trigger('change');
 }
 
 When('I set value {string}', When_I_set_value);

--- a/src/queries/value.ts
+++ b/src/queries/value.ts
@@ -22,12 +22,11 @@ import { setCypressElement } from '../utils';
  *
  * @remarks
  *
- * This precedes steps like {@link When_I_type | "When I type"}. For example:
+ * This precedes steps like {@link When_I_set_value | "When I set value"}. For example:
  *
  * ```gherkin
- * When I get element by display value "Hello World"
- *   And I clear
- *   And I type "user@example.com"
+ * When I get element by display value "Display Value"
+ *   And I set value "Value"
  * ```
  *
  * Inspired by Testing Library's [ByDisplayValue](https://testing-library.com/docs/queries/bydisplayvalue).
@@ -38,9 +37,9 @@ export function When_I_get_element_by_display_value(value: string) {
     let cypressElement;
 
     if (hasDisplayValue($body, 'input', value)) {
-      cypressElement = cy.get(`input[value='${value}']`).first();
+      cypressElement = getByDisplayValue('input', value);
     } else if (hasDisplayValue($body, 'textarea', value)) {
-      cypressElement = cy.contains('textarea', value);
+      cypressElement = getByDisplayValue('textarea', value);
     } else if (hasDisplayValue($body, 'option', value)) {
       cypressElement = cy.contains('option', value).closest('select');
     } else {
@@ -90,4 +89,20 @@ function hasDisplayValue(
   });
 
   return isFound;
+}
+
+/**
+ * Get Cypress element by display value.
+ *
+ * @param element - Element name.
+ * @param value - Display value.
+ */
+function getByDisplayValue(element: 'input' | 'textarea', value: string) {
+  return cy
+    .get(element)
+    .filter(
+      (index, element: HTMLInputElement) =>
+        Cypress.$(element).val()?.toString() === value
+    )
+    .first();
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(queries): get input and textarea by display value and not default value

## What is the current behavior?

Input/textarea is queried by default value

## What is the new behavior?

Input/textarea is queried by display value

See https://glebbahmutov.com/cypress-examples/recipes/get-inputs-with-value.html

Harden "When I set value" so `trigger('change')` does not fail after `invoke('val')` since DOM element may not exist after value is changed

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation