### PR TITLE
feat(utils): remove context arg from `getCypressElement` and `setCypressElement`

### DIFF
--- a/src/actions/click.ts
+++ b/src/actions/click.ts
@@ -36,7 +36,7 @@ import { getCypressElement } from '../utils';
  * - {@link When_I_right_click_on_text | When I right-click on text}
  */
 export function When_I_click() {
-  getCypressElement(this).click();
+  getCypressElement().click();
 }
 
 When('I click', When_I_click);
@@ -161,7 +161,7 @@ When('I click on text {string}', When_I_click_on_text);
  * - {@link When_I_right_click_on_text | When I right-click on text}
  */
 export function When_I_double_click() {
-  getCypressElement(this).dblclick();
+  getCypressElement().dblclick();
 }
 
 When('I double-click', When_I_double_click);
@@ -230,7 +230,7 @@ When('I double-click on text {string}', When_I_double_click_on_text);
  * - {@link When_I_double_click_on_text | When I double-click on text}
  */
 export function When_I_right_click() {
-  getCypressElement(this).rightclick();
+  getCypressElement().rightclick();
 }
 
 When('I right-click', When_I_right_click);

--- a/src/actions/scroll.ts
+++ b/src/actions/scroll.ts
@@ -30,7 +30,7 @@ import { camelCase, getCypressElement } from '../utils';
  * - {@link When_I_scroll_window_to_x_y_coordinates | When I scroll window to x-y coordinates}
  */
 export function When_I_scroll_into_view() {
-  getCypressElement(this).scrollIntoView();
+  getCypressElement().scrollIntoView();
 }
 
 When('I scroll into view', When_I_scroll_into_view);

--- a/src/actions/type.ts
+++ b/src/actions/type.ts
@@ -31,7 +31,7 @@ import { getCypressElement } from '../utils';
  * ```
  */
 export function When_I_clear() {
-  getCypressElement(this).clear();
+  getCypressElement().clear();
 }
 
 When('I clear', When_I_clear);
@@ -66,7 +66,7 @@ When('I clear', When_I_clear);
  * ```
  */
 export function When_I_type(text: string) {
-  getCypressElement(this).type(text);
+  getCypressElement().type(text);
 }
 
 When('I type {string}', When_I_type);

--- a/src/actions/value.ts
+++ b/src/actions/value.ts
@@ -25,7 +25,7 @@ import { getCypressElement } from '../utils';
  * ```
  */
 export function When_I_set_value(value: string) {
-  getCypressElement(this)
+  getCypressElement()
     .then((element) => Cypress.$(element).val(value))
     .trigger('change');
 }

--- a/src/assertions/element.ts
+++ b/src/assertions/element.ts
@@ -30,7 +30,7 @@ import { getCypressElement } from '../utils';
  * - {@link Then_I_see_text | Then I see text}
  */
 export function Then_I_see_element_is_visible() {
-  getCypressElement(this).should('be.visible');
+  getCypressElement().should('be.visible');
 }
 
 Then('I see element is visible', Then_I_see_element_is_visible);
@@ -64,7 +64,7 @@ Then('I see element is visible', Then_I_see_element_is_visible);
  * - {@link Then_I_see_element_is_visible | Then I see element is visible}
  */
 export function Then_I_see_element_is_not_visible() {
-  getCypressElement(this).should('not.be.visible');
+  getCypressElement().should('not.be.visible');
 }
 
 Then('I see element is not visible', Then_I_see_element_is_not_visible);

--- a/src/queries/alt.ts
+++ b/src/queries/alt.ts
@@ -29,7 +29,7 @@ import { setCypressElement } from '../utils';
  * Inspired by Testing Library's [ByAltText](https://testing-library.com/docs/queries/byalttext).
  */
 export function When_I_find_element_by_alt_text(altText: string) {
-  setCypressElement(this, cy.get(`[alt='${altText}']`));
+  setCypressElement(cy.get(`[alt='${altText}']`));
 }
 
 When('I find element by alt text {string}', When_I_find_element_by_alt_text);

--- a/src/queries/element.ts
+++ b/src/queries/element.ts
@@ -31,8 +31,7 @@ import { getCypressElement, setCypressElement } from '../utils';
  * - {@link When_I_get_nth_element | When I get nth element}
  */
 export function When_I_get_first_element() {
-  const cypressElement = getCypressElement(this);
-  setCypressElement(this, cypressElement.first());
+  setCypressElement(getCypressElement().first());
 }
 
 When('I get first element', When_I_get_first_element);
@@ -66,8 +65,7 @@ When('I get first element', When_I_get_first_element);
  * - {@link When_I_get_nth_element | When I get nth element}
  */
 export function When_I_get_last_element() {
-  const cypressElement = getCypressElement(this);
-  setCypressElement(this, cypressElement.last());
+  setCypressElement(getCypressElement().last());
 }
 
 When('I get last element', When_I_get_last_element);
@@ -109,9 +107,9 @@ When('I get last element', When_I_get_last_element);
  * @param position - A number indicating the position to find the element within an array of elements (starts with 1). If negative, the number indicates the position from the end to find the element.
  */
 export function When_I_get_nth_element(position: number) {
-  const cypressElement = getCypressElement(this);
+  const cypressElement = getCypressElement();
   const index = position > 0 ? position - 1 : position;
-  setCypressElement(this, cypressElement.eq(index));
+  setCypressElement(cypressElement.eq(index));
 }
 
 When('I get {int}st element', When_I_get_nth_element);

--- a/src/queries/label.ts
+++ b/src/queries/label.ts
@@ -44,7 +44,7 @@ export function When_I_get_element_by_label_text(text: string) {
       throw new Error(`Unable to get element by label text: ${text}`);
     }
 
-    setCypressElement(this, cypressElement);
+    setCypressElement(cypressElement);
   });
 }
 

--- a/src/queries/placeholder.ts
+++ b/src/queries/placeholder.ts
@@ -33,7 +33,7 @@ import { setCypressElement } from '../utils';
 export function When_I_find_element_by_placeholder_text(
   placeholderText: string
 ) {
-  setCypressElement(this, cy.get(`[placeholder='${placeholderText}']`));
+  setCypressElement(cy.get(`[placeholder='${placeholderText}']`));
 }
 
 When(

--- a/src/queries/testid.ts
+++ b/src/queries/testid.ts
@@ -37,7 +37,7 @@ import { setCypressElement } from '../utils';
  */
 /* eslint-enable tsdoc/syntax */
 export function When_I_find_element_by_testid(testId: string) {
-  setCypressElement(this, cy.get(`[data-testid='${testId}']`));
+  setCypressElement(cy.get(`[data-testid='${testId}']`));
 }
 
 When('I find element by test ID {string}', When_I_find_element_by_testid);

--- a/src/queries/text.ts
+++ b/src/queries/text.ts
@@ -33,7 +33,7 @@ import { setCypressElement } from '../utils';
  * - {@link When_I_find_link_by_text | When I find link by text}
  */
 export function When_I_find_button_by_text(text: string) {
-  setCypressElement(this, cy.contains('button', text));
+  setCypressElement(cy.contains('button', text));
 }
 
 When('I find button by text {string}', When_I_find_button_by_text);
@@ -67,7 +67,7 @@ When('I find button by text {string}', When_I_find_button_by_text);
  * - {@link When_I_find_links_by_text | When I find links by text}
  */
 export function When_I_find_buttons_by_text(text: string) {
-  setCypressElement(this, cy.get('button').contains(text));
+  setCypressElement(cy.get('button').contains(text));
 }
 
 When('I find buttons by text {string}', When_I_find_buttons_by_text);
@@ -102,7 +102,7 @@ When('I find buttons by text {string}', When_I_find_buttons_by_text);
  * - {@link When_I_find_link_by_text | When I find link by text}
  */
 export function When_I_find_element_by_text(text: string) {
-  setCypressElement(this, cy.contains(text));
+  setCypressElement(cy.contains(text));
 }
 
 When('I find element by text {string}', When_I_find_element_by_text);
@@ -138,7 +138,7 @@ When('I find element by text {string}', When_I_find_element_by_text);
  * - {@link When_I_find_links_by_text | When I find links by text}
  */
 export function When_I_find_link_by_text(text: string) {
-  setCypressElement(this, cy.contains('a', text));
+  setCypressElement(cy.contains('a', text));
 }
 
 When('I find link by text {string}', When_I_find_link_by_text);
@@ -172,7 +172,7 @@ When('I find link by text {string}', When_I_find_link_by_text);
  * - {@link When_I_find_link_by_text | When I find link by text}
  */
 export function When_I_find_links_by_text(text: string) {
-  setCypressElement(this, cy.get('a').contains(text));
+  setCypressElement(cy.get('a').contains(text));
 }
 
 When('I find links by text {string}', When_I_find_links_by_text);

--- a/src/queries/title.ts
+++ b/src/queries/title.ts
@@ -35,9 +35,9 @@ import { setCypressElement } from '../utils';
 export function When_I_get_element_by_title(title: string) {
   cy.get('body').then(($body) => {
     if ($body.find('svg title').text().includes(title)) {
-      setCypressElement(this, cy.get('svg title').contains(title));
+      setCypressElement(cy.get('svg title').contains(title));
     } else if ($body.find(`[title='${title}']`).length) {
-      setCypressElement(this, cy.get(`[title='${title}']`));
+      setCypressElement(cy.get(`[title='${title}']`));
     } else {
       throw new Error(`Unable to get element by title: ${title}`);
     }

--- a/src/queries/value.ts
+++ b/src/queries/value.ts
@@ -41,15 +41,15 @@ import { setCypressElement } from '../utils';
 export function When_I_get_element_by_display_value(value: string) {
   cy.get('body').then(($body) => {
     if (hasDisplayValue($body, 'input', value)) {
-      return When_I_find_input_by_display_value.call(this, value);
+      return When_I_find_input_by_display_value(value);
     }
 
     if (hasDisplayValue($body, 'textarea', value)) {
-      return When_I_find_textarea_by_display_value.call(this, value);
+      return When_I_find_textarea_by_display_value(value);
     }
 
     if (hasDisplayValue($body, 'option', value)) {
-      return When_I_find_select_by_display_value.call(this, value);
+      return When_I_find_select_by_display_value(value);
     }
 
     throw new Error(`Unable to get element by display value: ${value}`);
@@ -144,7 +144,7 @@ function getByDisplayValue(element: 'input' | 'textarea', value: string) {
  * - {@link When_I_get_element_by_display_value | When I get element by display value}
  */
 export function When_I_find_input_by_display_value(value: string) {
-  setCypressElement(this, getByDisplayValue('input', value));
+  setCypressElement(getByDisplayValue('input', value));
 }
 
 When(
@@ -183,7 +183,7 @@ When(
  * - {@link When_I_get_element_by_display_value | When I get element by display value}
  */
 export function When_I_find_textarea_by_display_value(value: string) {
-  setCypressElement(this, getByDisplayValue('textarea', value));
+  setCypressElement(getByDisplayValue('textarea', value));
 }
 
 When(
@@ -222,7 +222,7 @@ When(
  * - {@link When_I_get_element_by_display_value | When I get element by display value}
  */
 export function When_I_find_select_by_display_value(value: string) {
-  setCypressElement(this, cy.contains('option', value).closest('select'));
+  setCypressElement(cy.contains('option', value).closest('select'));
 }
 
 When(

--- a/src/utils/element.ts
+++ b/src/utils/element.ts
@@ -6,44 +6,41 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type CypressChainableElement = Cypress.Chainable<any>;
 
-/**
- * @private
- */
-export interface MochaContext extends Mocha.Context {
-  cypressElement?: CypressChainableElement;
-}
+let cypressElement: CypressChainableElement;
 
 /**
- * Set Cypress element on Mocha Context.
+ * Set Cypress element.
  *
  * @private
  *
- * @param context - Mocha context.
+ * @see
+ *
+ * - {@link getCypressElement}
+ *
  * @param element - Cypress element.
  */
-export function setCypressElement(
-  context: MochaContext,
-  element: CypressChainableElement
-) {
-  context.cypressElement = element;
+export function setCypressElement(element: CypressChainableElement): void {
+  cypressElement = element;
 }
 
 /**
- * Get Cypress element from Mocha Context.
+ * Get Cypress element.
  *
  * @private
  *
- * @param context - Mocha context.
+ * @see
+ *
+ * - {@link setCypressElement}
+ *
  * @returns - Cypress element.
  */
-export function getCypressElement(context: MochaContext) {
-  if (!Cypress.isCy(context.cypressElement)) {
+export function getCypressElement(): CypressChainableElement {
+  if (!Cypress.isCy(cypressElement)) {
     throw new Error(
-      `The element you are chaining off is ${context.cypressElement}.
+      `The element you are chaining off is ${cypressElement}.
 
 Add a preceding step "When I get element by ..." or "When I find element by ..."`
     );
   }
-
-  return context.cypressElement;
+  return cypressElement;
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(utils): remove context `this` argument from `getCypressElement` and `setCypressElement`

Although this is a breaking change, this will be a minor version bump since the utility helper is a private function

## What is the current behavior?

```ts
getCypressElement(this)
setCypressElement(this, ...)
```

## What is the new behavior?

```ts
getCypressElement()
setCypressElement(...)
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [x] Documentation