### PR TITLE
fix(assertions): query for visible elements in link, button, & label

### DIFF
--- a/src/assertions/button.ts
+++ b/src/assertions/button.ts
@@ -23,7 +23,7 @@ import { Then } from '@badeball/cypress-cucumber-preprocessor';
  * - {@link Then_I_see_text | Then I see text}
  */
 export function Then_I_see_button(text: string) {
-  cy.contains('button', text).should('exist').and('be.visible');
+  cy.contains('button:visible', text).should('exist');
 }
 
 Then('I see button {string}', Then_I_see_button);

--- a/src/assertions/link.ts
+++ b/src/assertions/link.ts
@@ -23,7 +23,7 @@ import { Then } from '@badeball/cypress-cucumber-preprocessor';
  * - {@link Then_I_see_text | Then I see text}
  */
 export function Then_I_see_link(text: string) {
-  cy.contains('a', text).should('exist').and('be.visible');
+  cy.contains('a:visible', text).should('exist');
 }
 
 Then('I see link {string}', Then_I_see_link);

--- a/src/queries/label.ts
+++ b/src/queries/label.ts
@@ -34,12 +34,12 @@ export function When_I_get_element_by_label_text(text: string) {
   cy.get('body').then(($body) => {
     let cypressElement;
 
-    if ($body.find('label').text().includes(text)) {
-      cypressElement = cy.contains('label', text);
-    } else if ($body.find(`[aria-labelledby='${text}']`).length) {
-      cypressElement = cy.get(`[aria-labelledby='${text}']`).first();
-    } else if ($body.find(`[aria-label='${text}']`).length) {
-      cypressElement = cy.get(`[aria-label='${text}']`).first();
+    if ($body.find('label:visible').text().includes(text)) {
+      cypressElement = cy.contains('label:visible', text);
+    } else if ($body.find(`[aria-labelledby='${text}']:visible`).length) {
+      cypressElement = cy.get(`[aria-labelledby='${text}']:visible`).first();
+    } else if ($body.find(`[aria-label='${text}']:visible`).length) {
+      cypressElement = cy.get(`[aria-label='${text}']:visible`).first();
     } else {
       throw new Error(`Unable to get element by label text: ${text}`);
     }


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(assertions): query for visible elements in link, button, and label

## What is the current behavior?

If there are hidden links or buttons, the assertion can fail

## What is the new behavior?

Assertion only queries visible links and buttons

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation