### PR TITLE
fix(assertions): correct find label logic in "Then I see label"

### DIFF
--- a/src/assertions/label.ts
+++ b/src/assertions/label.ts
@@ -27,10 +27,10 @@ export function Then_I_see_label(text: string) {
   cy.get('body').then(($body) => {
     if ($body.find('label:visible').text().includes(text)) {
       cy.contains('label:visible', text).should('exist');
-    } else if (!$body.find(`[aria-labelledby='${text}']:visible`).length) {
-      cy.contains(`[aria-labelledby='${text}']:visible`, text).should('exist');
-    } else if (!$body.find(`[aria-label='${text}']:visible`).length) {
-      cy.contains(`[aria-label='${text}']:visible`, text).should('exist');
+    } else if ($body.find(`[aria-labelledby='${text}']:visible`).length) {
+      cy.get(`[aria-labelledby='${text}']:visible`).should('exist');
+    } else if ($body.find(`[aria-label='${text}']:visible`).length) {
+      cy.get(`[aria-label='${text}']:visible`).should('exist');
     } else {
       throw new Error(`Unable to see label: ${text}`);
     }


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(assertions): correct find label logic in "Then I see label"

## What is the current behavior?

Find label logic for `aria-label` is inverted

## What is the new behavior?

Find label logic is corrected

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation