### PR TITLE
fix(queries): ensure multiple elements are returned

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/node": "18.11.18",
         "@typescript-eslint/eslint-plugin": "5.48.0",
         "@typescript-eslint/parser": "5.48.0",
-        "cypress": "12.2.0",
+        "cypress": "12.3.0",
         "eslint": "8.31.0",
         "eslint-plugin-prettier": "4.2.1",
         "eslint-plugin-simple-import-sort": "8.0.0",
@@ -1868,9 +1868,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.2.0.tgz",
-      "integrity": "sha512-kvl95ri95KK8mAy++tEU/wUgzAOMiIciZSL97LQvnOinb532m7dGvwN0mDSIGbOd71RREtmT9o4h088RjK5pKw==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
+      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -7485,9 +7485,9 @@
       }
     },
     "cypress": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.2.0.tgz",
-      "integrity": "sha512-kvl95ri95KK8mAy++tEU/wUgzAOMiIciZSL97LQvnOinb532m7dGvwN0mDSIGbOd71RREtmT9o4h088RjK5pKw==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
+      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/node": "18.11.18",
     "@typescript-eslint/eslint-plugin": "5.48.0",
     "@typescript-eslint/parser": "5.48.0",
-    "cypress": "12.2.0",
+    "cypress": "12.3.0",
     "eslint": "8.31.0",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-simple-import-sort": "8.0.0",

--- a/src/queries/text.ts
+++ b/src/queries/text.ts
@@ -67,7 +67,7 @@ When('I find button by text {string}', When_I_find_button_by_text);
  * - {@link When_I_find_links_by_text | When I find links by text}
  */
 export function When_I_find_buttons_by_text(text: string) {
-  setCypressElement(cy.get('button').contains(text));
+  setCypressElement(cy.get(`button:contains('${text}')`));
 }
 
 When('I find buttons by text {string}', When_I_find_buttons_by_text);
@@ -172,7 +172,7 @@ When('I find link by text {string}', When_I_find_link_by_text);
  * - {@link When_I_find_link_by_text | When I find link by text}
  */
 export function When_I_find_links_by_text(text: string) {
-  setCypressElement(cy.get('a').contains(text));
+  setCypressElement(cy.get(`a:contains('${text}')`));
 }
 
 When('I find links by text {string}', When_I_find_links_by_text);


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(queries): ensure multiple elements are returned 

## What is the current behavior?

cypress@12.3.0 fixes a regression in cypress-io/cypress#25225 that does not return multiple elements with `.contains`

See failure in lilboards/lilboards#988

## What is the new behavior?

The queries below are fixed and return multiple elements:

- When I find buttons by text
- When I find links by text

https://glebbahmutov.com/cypress-examples/recipes/find-by-class-or-text.html#find-multiple-elements-with-text

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation