### PR TITLE
fix(assertions): wait until text is found before heading assertion

### DIFF
--- a/src/assertions/heading.ts
+++ b/src/assertions/heading.ts
@@ -22,21 +22,38 @@ import { Then } from '@badeball/cypress-cucumber-preprocessor';
  * - {@link Then_I_see_text | Then I see text}
  */
 export function Then_I_see_heading(text: string) {
-  cy.get('body').then(($body) => {
-    const heading = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].reduce(
-      (previousValue, tagName) =>
-        $body.find(`${tagName}:visible`).text().includes(text)
-          ? tagName
-          : previousValue,
-      ''
-    );
+  // wait until text is found before making assertion
+  cy.contains(text)
+    .get('body')
+    .then(($body) => {
+      const heading = getHeadingTagByText($body, text);
 
-    if (!heading) {
-      throw new Error(`Unable to see heading: ${text}`);
-    }
+      if (!heading) {
+        throw new Error(`Unable to see heading: ${text}`);
+      }
 
-    cy.contains(`${heading}:visible`, text).should('exist');
-  });
+      cy.contains(`${heading}:visible`, text).should('exist');
+    });
 }
 
 Then('I see heading {string}', Then_I_see_heading);
+
+/**
+ * Get heading tag name by text.
+ *
+ * @param $body - jQuery body element.
+ * @param text - Text.
+ * @returns - Tag name.
+ */
+function getHeadingTagByText(
+  $body: JQuery<HTMLBodyElement>,
+  text: string
+): string {
+  return ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].reduce(
+    (previousValue, tagName) =>
+      $body.find(`${tagName}:visible`).text().includes(text)
+        ? tagName
+        : previousValue,
+    ''
+  );
+}


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(assertions): wait until text is found before heading assertion

## What is the current behavior?

Heading assertion happens immediately even when loading hasn't finished

## What is the new behavior?

Wait until text is found before heading assertion

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation