### PR TITLE
fix(assertions): correct heading selector in "Then I see heading"

### DIFF
--- a/src/assertions/heading.ts
+++ b/src/assertions/heading.ts
@@ -22,7 +22,10 @@ import { Then } from '@badeball/cypress-cucumber-preprocessor';
  * - {@link Then_I_see_text | Then I see text}
  */
 export function Then_I_see_heading(text: string) {
-  cy.get(`h1,h2,h3,h4,h5,h6:contains('${text}'):visible`).should('exist');
+  const selector = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+    .map((tag) => `${tag}:contains('${text}'):visible`)
+    .join(',');
+  cy.get(selector).should('exist');
 }
 
 Then('I see heading {string}', Then_I_see_heading);


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(assertions): correct heading selector in "Then I see heading"

## What is the current behavior?

Contains and visible are only applied on `h6` and not the other heading tags

## What is the new behavior?

Contains and visible are applied to all heading tags

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation