### PR TITLE
feat(queries): add "When I find element by title"

### DIFF
--- a/cypress/e2e/cypress/example.feature
+++ b/cypress/e2e/cypress/example.feature
@@ -124,8 +124,8 @@ Feature: Cypress example
     When I find select by display value "bananas"
       And I select option "bananas"
 
-  Scenario: Trigger event
+  Scenario: Find title and trigger event
     Given I visit "https://example.cypress.io/commands/actions"
-    When I find button by text "Click to toggle popover"
+    When I find element by title ""
       And I trigger event "click"
     Then I see heading "Popover"

--- a/src/queries/title.ts
+++ b/src/queries/title.ts
@@ -2,15 +2,53 @@ import { When } from '@badeball/cypress-cucumber-preprocessor';
 
 import { setCypressElement } from '../utils';
 
+/**
+ * When I find element by title:
+ *
+ * ```gherkin
+ * When I find element by title {string}
+ * ```
+ *
+ * Finds the first element that has a matching `title` attribute. This will also find a `title` element within an SVG.
+ *
+ * @example
+ *
+ * ```gherkin
+ * When I find element by title "Close"
+ * ```
+ *
+ * @remarks
+ *
+ * This precedes steps like {@link When_I_click | "When I click"}. For example:
+ *
+ * ```gherkin
+ * When I find element by title "Close"
+ *   And I click
+ * ```
+ *
+ * Inspired by Testing Library's [ByTitle](https://testing-library.com/docs/queries/bytitle).
+ */
+export function When_I_find_element_by_title(title: string) {
+  const selector = [
+    `svg title:contains('${title}')`,
+    `[title='${title}']`,
+  ].join(',');
+  setCypressElement(cy.get(selector).first());
+}
+
+When('I find element by title {string}', When_I_find_element_by_title);
+
 /* eslint-disable tsdoc/syntax */
 /**
+ * # _Deprecated_
+ *
  * When I get element by title:
  *
  * ```gherkin
  * When I get element by title {string}
  * ```
  *
- * Gets the element that has the matching `title` attribute. This will also find a `title` element within an SVG.
+ * Gets the first element that has a matching `title` attribute. This will also find a `title` element within an SVG.
  *
  * > This query will throw an error if no element is found and will not wait and retry.
  *
@@ -30,6 +68,8 @@ import { setCypressElement } from '../utils';
  * ```
  *
  * Inspired by Testing Library's [ByTitle](https://testing-library.com/docs/queries/bytitle).
+ *
+ * @deprecated Use {@link When_I_find_element_by_title | "When I find element by title"} instead.
  */
 /* eslint-enable tsdoc/syntax */
 export function When_I_get_element_by_title(title: string) {


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(queries): add "When I find element by title"

## What is the current behavior?

"When I get element by title"

## What is the new behavior?

Add "When I find element by title" and deprecate "When I get element by title"

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation