### PR TITLE
feat(queries): add "When I find element by label text"

### DIFF
--- a/cypress/e2e/cypress/docs.feature
+++ b/cypress/e2e/cypress/docs.feature
@@ -18,12 +18,9 @@ Feature: Cypress docs
 
   Scenario: Find and click aria-label
     Given I visit "https://docs.cypress.io/api/table-of-contents"
-      And I wait 3 seconds
     Then I see label "Search"
-    When I get element by label text "Search"
+    When I find element by label text "Search"
       And I click on label "Search"
       And I get focused element
-      And I type "lab"
-      And I wait 1 second
-      And I type "el"
-    Then I see link "label"
+      And I type "get"
+    Then I see link "get"

--- a/src/actions/click.ts
+++ b/src/actions/click.ts
@@ -140,9 +140,7 @@ When('I click on text {string}', When_I_click_on_text);
  * - {@link When_I_click_on_text | When I click on text}
  */
 export function When_I_click_on_label(text: string) {
-  setCypressElementByLabelText(text, `Unable to click label: ${text}`).then(
-    () => getCypressElement().click()
-  );
+  setCypressElementByLabelText(text).then(() => getCypressElement().click());
 }
 
 When('I click on label {string}', When_I_click_on_label);

--- a/src/actions/type.ts
+++ b/src/actions/type.ts
@@ -23,10 +23,10 @@ import { getCypressElement } from '../utils';
  *
  * @remarks
  *
- * This requires a preceding step like {@link When_I_get_element_by_label_text | "When I get element by label text"}. For example:
+ * This requires a preceding step like {@link When_I_find_element_by_label_text | "When I find element by label text"}. For example:
  *
  * ```gherkin
- * When I get element by label text "Input"
+ * When I find element by label text "Input"
  *   And I clear
  * ```
  */
@@ -51,10 +51,10 @@ When('I clear', When_I_clear);
  *
  * @remarks
  *
- * This requires a preceding step like {@link When_I_get_element_by_label_text | "When I get element by label text"}. For example:
+ * This requires a preceding step like {@link When_I_find_element_by_label_text | "When I find element by label text"}. For example:
  *
  * ```gherkin
- * When I get element by label text "Email"
+ * When I find element by label text "Email"
  *   And I type "user@example.com"
  * ```
  *

--- a/src/assertions/label.ts
+++ b/src/assertions/label.ts
@@ -26,7 +26,7 @@ import { getCypressElement, setCypressElementByLabelText } from '../utils';
  * - {@link Then_I_see_text | Then I see text}
  */
 export function Then_I_see_label(text: string) {
-  setCypressElementByLabelText(text, `Unable to see label: ${text}`).then(() =>
+  setCypressElementByLabelText(text).then(() =>
     getCypressElement().should('exist')
   );
 }

--- a/src/queries/label.ts
+++ b/src/queries/label.ts
@@ -2,20 +2,19 @@ import { When } from '@badeball/cypress-cucumber-preprocessor';
 
 import { setCypressElementByLabelText } from '../utils';
 
-/* eslint-disable tsdoc/syntax */
 /**
- * When I get element by label text:
+ * When I find element by label text:
  *
  * ```gherkin
- * When I get element by label text {string}
+ * When I find element by label text {string}
  * ```
  *
- * > This query will throw an error if no element is found and will not wait and retry.
+ * Finds the first `label`, `aria-labelledby`, or `aria-label` that matches the text.
  *
  * @example
  *
  * ```gherkin
- * When I get element by label text "Email"
+ * When I find element by label text "Email"
  * ```
  *
  * @remarks
@@ -23,18 +22,22 @@ import { setCypressElementByLabelText } from '../utils';
  * This precedes steps like {@link When_I_type | "When I type"}. For example:
  *
  * ```gherkin
- * When I get element by label text "Email"
+ * When I find element by label text "Email"
  *   And I type "user@example.com"
  * ```
  *
  * Inspired by Testing Library's [ByLabelText](https://testing-library.com/docs/queries/bylabeltext).
  */
-/* eslint-enable tsdoc/syntax */
-export function When_I_get_element_by_label_text(text: string) {
-  setCypressElementByLabelText(
-    text,
-    `Unable to get element by label text: ${text}`
-  );
+export function When_I_find_element_by_label_text(text: string) {
+  setCypressElementByLabelText(text);
 }
 
-When('I get element by label text {string}', When_I_get_element_by_label_text);
+When(
+  'I find element by label text {string}',
+  When_I_find_element_by_label_text
+);
+
+/**
+ * @deprecated Use {@link When_I_find_element_by_label_text | "When I find element by label text"} instead.
+ */
+When('I get element by label text {string}', When_I_find_element_by_label_text);

--- a/src/queries/placeholder.ts
+++ b/src/queries/placeholder.ts
@@ -10,7 +10,7 @@ import { setCypressElement } from '../utils';
  * When I find element by placeholder text {string}
  * ```
  *
- * > Placeholder is not a good substitute for label so prefer {@link When_I_get_element_by_label_text | "When I get element by label text "} instead.
+ * > Placeholder is not a good substitute for label so prefer {@link When_I_find_element_by_label_text | "When I find element by label text "} instead.
  *
  * @example
  *

--- a/src/utils/label.ts
+++ b/src/utils/label.ts
@@ -20,30 +20,18 @@ import { setCypressElement } from '../utils';
  * - {@link getCypressElement}
  * - {@link setCypressElement}
  *
- * @param labelText - Label text.
- * @param errorMessage - Error message.
+ * @param text - Label text.
  *
  * @private
  */
-export function setCypressElementByLabelText(
-  labelText: string,
-  errorMessage: string
-) {
-  return cy.get('body').then(($body) => {
-    let cypressElement;
-
-    if ($body.find('label:visible').text().includes(labelText)) {
-      cypressElement = cy.contains('label:visible', labelText);
-    } else if ($body.find(`[aria-labelledby='${labelText}']:visible`).length) {
-      cypressElement = cy
-        .get(`[aria-labelledby='${labelText}']:visible`)
-        .first();
-    } else if ($body.find(`[aria-label='${labelText}']:visible`).length) {
-      cypressElement = cy.get(`[aria-label='${labelText}']:visible`).first();
-    } else {
-      throw new Error(errorMessage);
-    }
-
-    setCypressElement(cypressElement);
-  });
+export function setCypressElementByLabelText(text: string) {
+  const cypressElement = cy.get(
+    [
+      `label:visible:contains('${text}')`,
+      `[aria-labelledby='${text}']`,
+      `[aria-label='${text}']`,
+    ].join(',')
+  );
+  setCypressElement(cypressElement.first());
+  return cypressElement;
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(queries): add "When I find element by label text"

## What is the current behavior?

"When I get element by label text" doesn't retry which causes tests to be flaky

## What is the new behavior?

"When I find element by label text" retries so tests are hardened

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation