### PR TITLE
fix(queries): find and return 1 visible element

### DIFF
--- a/cypress/e2e/cypress/docs.feature
+++ b/cypress/e2e/cypress/docs.feature
@@ -1,9 +1,9 @@
 Feature: Cypress docs
   Scenario: Alt text
     Given I visit "https://docs.cypress.io/plugins/directory"
-      And I find element by alt text "Cypress Docs Logo"
+      And I find element by alt text "Cypress Logo"
       And I click
-    Then I see URL "https://docs.cypress.io/"
+    Then I see URL contains "https://docs.cypress.io/"
 
   Scenario: Go back and forward
     Given I visit "https://docs.cypress.io/api/commands/go"
@@ -17,12 +17,14 @@ Feature: Cypress docs
     Then I see URL contains "go"
 
   Scenario: Set Cypress config and find and click aria-label
-    Given I visit "https://docs.cypress.io/api/table-of-contents"
+    Given I visit "https://docs.cypress.io/plugins"
       And I set Cypress config "baseUrl" to "null"
       And I set Cypress config "defaultCommandTimeout" to "10000"
+      And I wait 1 second
     Then I see label "Search"
     When I find element by label text "Search"
       And I click on label "Search"
       And I get focused element
+      And I wait 300 milliseconds
       And I type "get"
     Then I see link "get"

--- a/src/queries/alt.ts
+++ b/src/queries/alt.ts
@@ -29,7 +29,7 @@ import { setCypressElement } from '../utils';
  * Inspired by Testing Library's [ByAltText](https://testing-library.com/docs/queries/byalttext).
  */
 export function When_I_find_element_by_alt_text(altText: string) {
-  setCypressElement(cy.get(`[alt='${altText}']`));
+  setCypressElement(cy.get(`[alt='${altText}']:visible`).first());
 }
 
 When('I find element by alt text {string}', When_I_find_element_by_alt_text);

--- a/src/queries/placeholder.ts
+++ b/src/queries/placeholder.ts
@@ -33,7 +33,9 @@ import { setCypressElement } from '../utils';
 export function When_I_find_element_by_placeholder_text(
   placeholderText: string
 ) {
-  setCypressElement(cy.get(`[placeholder='${placeholderText}']`));
+  setCypressElement(
+    cy.get(`[placeholder='${placeholderText}']:visible`).first()
+  );
 }
 
 When(

--- a/src/queries/testid.ts
+++ b/src/queries/testid.ts
@@ -37,7 +37,7 @@ import { setCypressElement } from '../utils';
  */
 /* eslint-enable tsdoc/syntax */
 export function When_I_find_element_by_testid(testId: string) {
-  setCypressElement(cy.get(`[data-testid='${testId}']`));
+  setCypressElement(cy.get(`[data-testid='${testId}']:visible`).first());
 }
 
 When('I find element by test ID {string}', When_I_find_element_by_testid);


### PR DESCRIPTION
## What is the motivation for this pull request?

Fix queries to find and return 1 visible element

Harden Cypress docs tests

## What is the current behavior?

Step can return multiple elements:

- When I find element by alt text
- When I find element by placeholder text
- When I find element by test ID

## What is the new behavior?

Step returns single visible element:

- When I find element by alt text
- When I find element by placeholder text
- When I find element by test ID

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation