### PR TITLE
fix(queries): get first visible element by display value

### DIFF
--- a/src/queries/value.ts
+++ b/src/queries/value.ts
@@ -102,10 +102,11 @@ function hasDisplayValue(
  *
  * @param element - Element name.
  * @param value - Display value.
+ * @returns - Cypress element.
  */
 function getByDisplayValue(element: 'input' | 'textarea', value: string) {
   return cy
-    .get(element)
+    .get(`${element}:visible`)
     .filter(
       (index, element: HTMLInputElement) =>
         Cypress.$(element).val()?.toString() === value
@@ -222,7 +223,7 @@ When(
  * - {@link When_I_get_element_by_display_value | When I get element by display value}
  */
 export function When_I_find_select_by_display_value(value: string) {
-  setCypressElement(cy.contains('option', value).closest('select'));
+  setCypressElement(cy.contains('option', value).closest('select').first());
 }
 
 When(


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(queries): get first visible element by display value

- When I get element by display value
- When I find input by display value
- When I find select by display value
- When I find textarea by display value

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation