### PR TITLE
docs: add TypeDoc plugin to copy code to clipboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "pinst": "3.0.0",
         "prettier": "2.8.3",
         "typedoc": "0.23.24",
+        "typedoc-plugin-copy-code-to-clipboard": "1.0.0",
         "typescript": "4.9.4"
       },
       "peerDependencies": {
@@ -5806,6 +5807,15 @@
         "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
       }
     },
+    "node_modules/typedoc-plugin-copy-code-to-clipboard": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-copy-code-to-clipboard/-/typedoc-plugin-copy-code-to-clipboard-1.0.0.tgz",
+      "integrity": "sha512-soOAYuoFF4wdmeRAGDLwc/X6djroEIuaz2+vGZdn6fZQ9A6mAITU0RbKiRIo9zbISAXBc9uQplIM2+idoGt+CA==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": "^0.23"
+      }
+    },
     "node_modules/typedoc/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -10244,6 +10254,13 @@
           }
         }
       }
+    },
+    "typedoc-plugin-copy-code-to-clipboard": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-copy-code-to-clipboard/-/typedoc-plugin-copy-code-to-clipboard-1.0.0.tgz",
+      "integrity": "sha512-soOAYuoFF4wdmeRAGDLwc/X6djroEIuaz2+vGZdn6fZQ9A6mAITU0RbKiRIo9zbISAXBc9uQplIM2+idoGt+CA==",
+      "dev": true,
+      "requires": {}
     },
     "typescript": {
       "version": "4.9.4",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "pinst": "3.0.0",
     "prettier": "2.8.3",
     "typedoc": "0.23.24",
+    "typedoc-plugin-copy-code-to-clipboard": "1.0.0",
     "typescript": "4.9.4"
   },
   "peerDependencies": {

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,3 +1,4 @@
 {
-  "entryPoints": ["src"]
+  "entryPoints": ["src"],
+  "plugin": ["typedoc-plugin-copy-code-to-clipboard"]
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

docs: add TypeDoc plugin to copy code to clipboard

https://github.com/remarkablemark/typedoc-plugin-copy-code-to-clipboard

## What is the current behavior?

Cannot copy code to clipboard in docs

## What is the new behavior?

Can copy code to clipboard in docs

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [x] Documentation