### PR TITLE
feat(assertions): add "I see document title" & "I see document contains"

### DIFF
--- a/cypress/e2e/example/example.feature
+++ b/cypress/e2e/example/example.feature
@@ -1,4 +1,9 @@
 Feature: Example
+  Scenario: See document title
+    Given I visit "https://example.com/"
+    Then I see document title "Example Domain"
+      And I see document title contains "Example"
+
   Scenario: See and not see text
     Given I visit "https://example.com/"
     Then I see text "Example Domain"

--- a/src/assertions/document-title.ts
+++ b/src/assertions/document-title.ts
@@ -1,0 +1,54 @@
+import { Then } from '@badeball/cypress-cucumber-preprocessor';
+
+/**
+ * Then I see document title:
+ *
+ * ```gherkin
+ * Then I see document title {string}
+ * ```
+ *
+ * @example
+ *
+ * Assert that the `document.title` property of the page is "Title":
+ *
+ * ```gherkin
+ * Then I see document title "Title"
+ * ```
+ *
+ * @see
+ *
+ * - {@link Then_I_see_document_title_contains | Then I see document title contains}
+ */
+export function Then_I_see_document_title(title: string) {
+  cy.title().should('equal', title);
+}
+
+Then('I see document title {string}', Then_I_see_document_title);
+
+/**
+ * Then I see document title contains:
+ *
+ * ```gherkin
+ * Then I see document title contains {string}
+ * ```
+ *
+ * @example
+ *
+ * Assert that the document's title contains "Title":
+ *
+ * ```gherkin
+ * Then I see document title contains "Title"
+ * ```
+ *
+ * @see
+ *
+ * - {@link Then_I_see_document_title | Then I see document title}
+ */
+export function Then_I_see_document_title_contains(title: string) {
+  cy.title().should('contain', title);
+}
+
+Then(
+  'I see document title contains {string}',
+  Then_I_see_document_title_contains
+);

--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -1,4 +1,5 @@
 export * from './button';
+export * from './document-title';
 export * from './element';
 export * from './hash';
 export * from './heading';


### PR DESCRIPTION
## What is the motivation for this pull request?

Add assertions:

- "I see document title"
- "I see document contains"

https://docs.cypress.io/api/commands/title

## What is the current behavior?

No document title assertions

## What is the new behavior?

Document title assertions

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation