### PR TITLE
feat(queries): add "When I find elements by alt text"

### DIFF
--- a/cypress/e2e/cypress/docs.feature
+++ b/cypress/e2e/cypress/docs.feature
@@ -2,6 +2,7 @@ Feature: Cypress docs
   Scenario: Alt text
     Given I set viewport to "ipad-mini"
     When I visit "https://docs.cypress.io/plugins/directory"
+      And I find elements by alt text "Cypress Logo"
       And I find element by alt text "Cypress Logo"
       And I click
     Then I see URL contains "https://docs.cypress.io/"

--- a/src/queries/alt-text.ts
+++ b/src/queries/alt-text.ts
@@ -27,6 +27,10 @@ import { setCypressElement } from '../utils';
  * ```
  *
  * Inspired by Testing Library's [ByAltText](https://testing-library.com/docs/queries/byalttext).
+ *
+ * @see
+ *
+ * - {@link When_I_find_elements_by_alt_text | When I find elements by alt text}
  */
 export function When_I_find_element_by_alt_text(altText: string) {
   setCypressElement(cy.get(`[alt='${altText}']:visible`).first());

--- a/src/queries/alt-texts.ts
+++ b/src/queries/alt-texts.ts
@@ -1,0 +1,40 @@
+import { When } from '@badeball/cypress-cucumber-preprocessor';
+
+import { setCypressElement } from '../utils';
+
+/**
+ * When I find elements by alt text:
+ *
+ * ```gherkin
+ * When I find elements by alt text {string}
+ * ```
+ *
+ * This finds elements (`<img>`) that match the `alt` text.
+ *
+ * @example
+ *
+ * ```gherkin
+ * When I find elements by alt text "Image Description"
+ * ```
+ *
+ * @remarks
+ *
+ * This precedes steps like {@link When_I_click | "When I click"}. For example:
+ *
+ * ```gherkin
+ * When I find elements by alt text "Image Description"
+ *   And I get 1st element
+ *   And I click
+ * ```
+ *
+ * Inspired by Testing Library's [ByAltText](https://testing-library.com/docs/queries/byalttext).
+ *
+ * @see
+ *
+ * - {@link When_I_find_element_by_alt_text | When I find element by alt text}
+ */
+export function When_I_find_elements_by_alt_text(altText: string) {
+  setCypressElement(cy.get(`[alt='${altText}']:visible`));
+}
+
+When('I find elements by alt text {string}', When_I_find_elements_by_alt_text);

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,4 +1,5 @@
 export * from './alt-text';
+export * from './alt-texts';
 export * from './button';
 export * from './buttons';
 export * from './element';


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(queries): add "When I find elements by alt text"

## What is the current behavior?

No step to find elements by alt text

## What is the new behavior?

Step to find elements by alt text

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation