### PR TITLE
feat(assertions): add "Then I see element has attribute", "Then I see element has attribute equal to", "Then I see element has attribute containing"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ lib/
 
 # Mac OS
 .DS_Store
+
+# Test
+cypress/screenshots/

--- a/cypress/e2e/example/example.feature
+++ b/cypress/e2e/example/example.feature
@@ -17,8 +17,10 @@ Feature: Example
 
   Scenario: See attribute
     Given I visit "https://example.com/"
-    When I find link by text "More information"
+    When I find element by text "More information"
     Then I see element has attribute "href"
+    When I find link by text "More information"
+    Then I see element has attribute "href" equal to "https://www.iana.org/domains/example"
 
   Scenario: Reload and assert URL
     Given I visit "https://example.com/index.html"

--- a/cypress/e2e/example/example.feature
+++ b/cypress/e2e/example/example.feature
@@ -15,6 +15,11 @@ Feature: Example
     Then I see link "More information"
       And I do not see link "Lorem ipsum"
 
+  Scenario: See attribute
+    Given I visit "https://example.com/"
+    When I find link by text "More information"
+    Then I see element has attribute "href"
+
   Scenario: Reload and assert URL
     Given I visit "https://example.com/index.html"
       And I reload the page

--- a/cypress/e2e/example/example.feature
+++ b/cypress/e2e/example/example.feature
@@ -21,6 +21,8 @@ Feature: Example
     Then I see element has attribute "href"
     When I find link by text "More information"
     Then I see element has attribute "href" equal to "https://www.iana.org/domains/example"
+    When I find link by text "More information..."
+    Then I see element has attribute "href" containing "example"
 
   Scenario: Reload and assert URL
     Given I visit "https://example.com/index.html"

--- a/src/assertions/attribute.ts
+++ b/src/assertions/attribute.ts
@@ -1,0 +1,31 @@
+import { Then } from '@badeball/cypress-cucumber-preprocessor';
+
+import { getCypressElement } from '../utils';
+
+/**
+ * Then I see element has attribute:
+ *
+ * ```gherkin
+ * Then I see element has attribute {string}
+ * ```
+ *
+ * @example
+ *
+ * ```gherkin
+ * Then I see element has attribute "attribute"
+ * ```
+ *
+ * @remarks
+ *
+ * This requires a preceding step like {@link When_I_find_element_by_text | "When I find element by text"}. For example:
+ *
+ * ```gherkin
+ * When I find link by text "Link"
+ * Then I see element has attribute "href"
+ * ```
+ */
+export function Then_I_see_element_has_attribute(attribute: string) {
+  getCypressElement().should('have.attr', attribute);
+}
+
+Then('I see element has attribute {string}', Then_I_see_element_has_attribute);

--- a/src/assertions/attribute.ts
+++ b/src/assertions/attribute.ts
@@ -12,20 +12,62 @@ import { getCypressElement } from '../utils';
  * @example
  *
  * ```gherkin
- * Then I see element has attribute "attribute"
+ * Then I see element has attribute "name"
  * ```
  *
  * @remarks
  *
- * This requires a preceding step like {@link When_I_find_element_by_text | "When I find element by text"}. For example:
+ * A preceding step like {@link When_I_find_element_by_text | "When I find element by text"} is required. For example:
  *
  * ```gherkin
  * When I find link by text "Link"
  * Then I see element has attribute "href"
  * ```
+ *
+ * @see
+ *
+ * - {@link Then_I_see_element_has_attribute_equal_to | Then I see element has attribute equal to}
  */
-export function Then_I_see_element_has_attribute(attribute: string) {
-  getCypressElement().should('have.attr', attribute);
+export function Then_I_see_element_has_attribute(attributeName: string) {
+  getCypressElement().should('have.attr', attributeName);
 }
 
 Then('I see element has attribute {string}', Then_I_see_element_has_attribute);
+
+/**
+ * Then I see element has attribute equal to:
+ *
+ * ```gherkin
+ * Then I see element has attribute {string} equal to {string}
+ * ```
+ *
+ * @example
+ *
+ * ```gherkin
+ * Then I see element has attribute "name" equal to "value"
+ * ```
+ *
+ * @remarks
+ *
+ * A preceding step like {@link When_I_find_element_by_text | "When I find element by text"} is required. For example:
+ *
+ * ```gherkin
+ * When I find link by text "Link"
+ * Then I see element has attribute "href" equal to "/"
+ * ```
+ *
+ * @see
+ *
+ * - {@link Then_I_see_element_has_attribute | Then I see element has attribute}
+ */
+export function Then_I_see_element_has_attribute_equal_to(
+  attributeName: string,
+  attributeValue: string
+) {
+  getCypressElement().should('have.attr', attributeName, attributeValue);
+}
+
+Then(
+  'I see element has attribute {string} equal to {string}',
+  Then_I_see_element_has_attribute_equal_to
+);

--- a/src/assertions/attribute.ts
+++ b/src/assertions/attribute.ts
@@ -27,6 +27,7 @@ import { getCypressElement } from '../utils';
  * @see
  *
  * - {@link Then_I_see_element_has_attribute_equal_to | Then I see element has attribute equal to}
+ * - {@link Then_I_see_element_has_attribute_containing | Then I see element has attribute containing}
  */
 export function Then_I_see_element_has_attribute(attributeName: string) {
   getCypressElement().should('have.attr', attributeName);
@@ -59,6 +60,7 @@ Then('I see element has attribute {string}', Then_I_see_element_has_attribute);
  * @see
  *
  * - {@link Then_I_see_element_has_attribute | Then I see element has attribute}
+ * - {@link Then_I_see_element_has_attribute_containing | Then I see element has attribute containing}
  */
 export function Then_I_see_element_has_attribute_equal_to(
   attributeName: string,
@@ -70,4 +72,45 @@ export function Then_I_see_element_has_attribute_equal_to(
 Then(
   'I see element has attribute {string} equal to {string}',
   Then_I_see_element_has_attribute_equal_to
+);
+
+/**
+ * Then I see element has attribute containing:
+ *
+ * ```gherkin
+ * Then I see element has attribute {string} containing {string}
+ * ```
+ *
+ * @example
+ *
+ * ```gherkin
+ * Then I see element has attribute "name" containing "value"
+ * ```
+ *
+ * @remarks
+ *
+ * A preceding step like {@link When_I_find_element_by_text | "When I find element by text"} is required. For example:
+ *
+ * ```gherkin
+ * When I find link by text "Link"
+ * Then I see element has attribute "href" containing "/"
+ * ```
+ *
+ * @see
+ *
+ * - {@link Then_I_see_element_has_attribute | Then I see element has attribute}
+ * - {@link Then_I_see_element_has_attribute_equal_to | Then I see element has attribute equal to}
+ */
+export function Then_I_see_element_has_attribute_containing(
+  attributeName: string,
+  attributeValue: string
+) {
+  getCypressElement()
+    .should('have.attr', attributeName)
+    .and('include', attributeValue);
+}
+
+Then(
+  'I see element has attribute {string} containing {string}',
+  Then_I_see_element_has_attribute_containing
 );

--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -1,3 +1,4 @@
+export * from './attribute';
 export * from './button';
 export * from './document-title';
 export * from './hash';


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(assertions): add attribute assertions

- Then I see element has attribute
- Then I see element has attribute equal to
- Then I see element has attribute containing

## What is the current behavior?

No attribute assertions

## What is the new behavior?

Attribute assertions

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation