### PR TITLE
feat(assertions): add "Then I count elements length"

### DIFF
--- a/cypress/e2e/cypress/example.feature
+++ b/cypress/e2e/cypress/example.feature
@@ -105,6 +105,13 @@ Feature: Cypress example
       And I click
     Then I see URL "https://example.cypress.io/"
 
+  Scenario: Count elements length
+    Given I visit "https://example.cypress.io/commands/aliasing"
+    When I find buttons by text "Get Comment"
+    Then I count 1 element
+    When I find buttons by text "Change"
+    Then I count 4 elements
+
   Scenario: Find and set input value
     Given I visit "https://example.cypress.io/commands/actions"
     When I double-click on text "Double click to edit"

--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -4,6 +4,7 @@ export * from './document-title';
 export * from './hash';
 export * from './heading';
 export * from './label';
+export * from './length';
 export * from './link';
 export * from './text';
 export * from './url';

--- a/src/assertions/length.ts
+++ b/src/assertions/length.ts
@@ -1,0 +1,32 @@
+import { Then } from '@badeball/cypress-cucumber-preprocessor';
+
+import { getCypressElement } from '../utils';
+
+/**
+ * Then I count elements length:
+ *
+ * ```gherkin
+ * Then I count {int} elements
+ * ```
+ *
+ * @example
+ *
+ * Assert 10 elements are found:
+ *
+ * ```gherkin
+ * Then I count 10 elements
+ * ```
+ *
+ * A preceding step like {@link When_I_find_links_by_text | "When I find links by text"} is required. For example:
+ *
+ * ```gherkin
+ * When I find links by text "Link"
+ * Then I count 1 element
+ * ```
+ */
+export function Then_I_count_elements_length(count: number) {
+  getCypressElement().should('have.length', count);
+}
+
+Then('I count {int} element', Then_I_count_elements_length);
+Then('I count {int} elements', Then_I_count_elements_length);


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(assertions): add "Then I count elements length"

## What is the current behavior?

No way to assert elements length

## What is the new behavior?

Added elements length assertion

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation