### PR TITLE
feat(queries): add "When I find closest element"

### DIFF
--- a/cypress/e2e/cypress/example.feature
+++ b/cypress/e2e/cypress/example.feature
@@ -153,3 +153,10 @@ Feature: Cypress example
       And I get 5th element
       And I submit
     Then I see text "Your form has been submitted!"
+
+  Scenario: Find closest element
+    Given I visit "https://example.cypress.io/commands/actions"
+    When I find element by label text "Coupon Code"
+      And I find closest element "form"
+      And I submit
+    Then I see text "Your form has been submitted!"

--- a/src/queries/closest.ts
+++ b/src/queries/closest.ts
@@ -1,0 +1,38 @@
+import { When } from '@badeball/cypress-cucumber-preprocessor';
+
+import { getCypressElement, setCypressElement } from '../utils';
+
+/**
+ * When I find closest element:
+ *
+ * ```gherkin
+ * When I find closest element {string}
+ * ```
+ *
+ * Get the first DOM element that matches the selector (whether it be itself or one of its ancestors).
+ *
+ * The querying behavior matches exactly how [.closest()](http://api.jquery.com/closest) works in jQuery.
+ *
+ * @example
+ *
+ * Find the closest element with the class `banner`:
+ *
+ * ```gherkin
+ * When I find closest element ".banner"
+ * ```
+ *
+ * @remarks
+ *
+ * A preceding step like {@link When_I_find_element_by_label_text | "When I find element by label text"} is required. For example:
+ *
+ * ```gherkin
+ * When I get element by label text "Text"
+ *   And I find closest element "form"
+ *   And I submit
+ * ```
+ */
+export function When_I_find_closest_element(selector: string) {
+  setCypressElement(getCypressElement().closest(selector));
+}
+
+When('I find closest element {string}', When_I_find_closest_element);

--- a/src/queries/closest.ts
+++ b/src/queries/closest.ts
@@ -11,7 +11,7 @@ import { getCypressElement, setCypressElement } from '../utils';
  *
  * Get the first DOM element that matches the selector (whether it be itself or one of its ancestors).
  *
- * The querying behavior matches exactly how [.closest()](http://api.jquery.com/closest) works in jQuery.
+ * The querying behavior matches exactly how [`.closest()`](https://api.jquery.com/closest) works in jQuery.
  *
  * @example
  *

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -2,6 +2,7 @@ export * from './alt-text';
 export * from './alt-texts';
 export * from './button';
 export * from './buttons';
+export * from './closest';
 export * from './element';
 export * from './focused';
 export * from './form';


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(queries): add "When I find closest element"

https://docs.cypress.io/api/commands/closest

## What is the current behavior?

No step to find closest element

## What is the new behavior?

Step to find closest element

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation