### PR TITLE
feat(actions): add "When I use fake timers" and "When I use real timers"

### DIFF
--- a/cypress/e2e/cypress/example.feature
+++ b/cypress/e2e/cypress/example.feature
@@ -160,3 +160,11 @@ Feature: Cypress example
       And I find closest element "form"
       And I submit
     Then I see text "Your form has been submitted!"
+
+  Scenario: Timers
+    Given I visit "https://example.cypress.io/commands/spies-stubs-clocks"
+    When I use fake timers
+      And I click on text "Click for current time!"
+    Then I see text "0"
+    When I use real timers
+      And I click on text "Click for current time!"

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -16,6 +16,7 @@ export * from './scroll';
 export * from './select';
 export * from './session-storage';
 export * from './submit';
+export * from './timer';
 export * from './trigger';
 export * from './type';
 export * from './value';

--- a/src/actions/timer.ts
+++ b/src/actions/timer.ts
@@ -1,0 +1,34 @@
+import { When } from '@badeball/cypress-cucumber-preprocessor';
+
+/**
+ * When I use fake timers:
+ *
+ * ```gherkin
+ * When I use fake timers
+ * ```
+ *
+ * @example
+ *
+ * Enable fake timers and set system time to Unix epoch:
+ *
+ * ```gherkin
+ * When I use fake timers
+ * ```
+ *
+ * @remarks
+ *
+ * Overrides native global functions related to time allowing them to be controlled synchronously. This includes controlling:
+ *
+ * - `setTimeout`
+ * - `clearTimeout`
+ * - `setInterval`
+ * - `clearInterval`
+ * - `Date`
+ *
+ * The clock starts at the Unix epoch (timestamp of 0). This means that when you instantiate `new Date` in your application, it will have a time of `January 1st, 1970`.
+ */
+export function When_I_use_fake_timers() {
+  cy.clock();
+}
+
+When('I use fake timers', When_I_use_fake_timers);

--- a/src/actions/timer.ts
+++ b/src/actions/timer.ts
@@ -26,9 +26,44 @@ import { When } from '@badeball/cypress-cucumber-preprocessor';
  * - `Date`
  *
  * The clock starts at the Unix epoch (timestamp of 0). This means that when you instantiate `new Date` in your application, it will have a time of `January 1st, 1970`.
+ *
+ * @see
+ *
+ * - {@link When_I_use_real_timers | When I use real timers}
  */
 export function When_I_use_fake_timers() {
   cy.clock();
 }
 
 When('I use fake timers', When_I_use_fake_timers);
+
+/**
+ * When I use real timers:
+ *
+ * ```gherkin
+ * When I use real timers
+ * ```
+ *
+ * Restores timers to their normal behavior.
+ *
+ * @example
+ *
+ * Restore the clock and allow your application to resume normally without manipulating native global functions related to time:
+ *
+ * ```gherkin
+ * When I use real timers
+ * ```
+ *
+ * @remarks
+ *
+ * This is automatically called between tests, so should not generally be needed.
+ *
+ * @see
+ *
+ * - {@link When_I_use_fake_timers | When I use fake timers}
+ */
+export function When_I_use_real_timers() {
+  cy.clock().invoke('restore');
+}
+
+When('I use real timers', When_I_use_real_timers);


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(actions): add "When I use fake timers" and "When I use real timers"

Inspired by:

- https://docs.cypress.io/api/commands/clock
- https://jestjs.io/docs/timer-mocks

## What is the current behavior?

No steps:

- When I use fake timers
- When I use real timers

## What is the new behavior?

Added steps:

- When I use fake timers
- When I use real timers

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation