### PR TITLE
feat(actions): add "When I set system time"

### DIFF
--- a/cypress/e2e/cypress/example.feature
+++ b/cypress/e2e/cypress/example.feature
@@ -164,7 +164,13 @@ Feature: Cypress example
   Scenario: Timers
     Given I visit "https://example.cypress.io/commands/spies-stubs-clocks"
     When I use fake timers
+      And I set system time to 1234567890000
       And I click on text "Click for current time!"
-    Then I see text "0"
+    Then I see text "1234567890"
+    When I reload the page
+      And I set system time to "2020-02-02"
+      And I click on text "Click for current time!"
+    Then I see text "1580601600"
     When I use real timers
       And I click on text "Click for current time!"
+    Then I do not see text "15806016000"

--- a/src/actions/timer.ts
+++ b/src/actions/timer.ts
@@ -30,6 +30,7 @@ import { When } from '@badeball/cypress-cucumber-preprocessor';
  * @see
  *
  * - {@link When_I_use_real_timers | When I use real timers}
+ * - {@link When_I_set_system_time | When I set system time}
  */
 export function When_I_use_fake_timers() {
   cy.clock();
@@ -67,3 +68,44 @@ export function When_I_use_real_timers() {
 }
 
 When('I use real timers', When_I_use_real_timers);
+
+/**
+ * When I set system time:
+ *
+ * ```gherkin
+ * When I set system time to {int}
+ * When I set system time to {string}
+ * ```
+ *
+ * @example
+ *
+ * Change current system time to Unix epoch:
+ *
+ * ```gherkin
+ * When I set system time to 0
+ * ```
+ *
+ * Change current system time to `2020-02-02`:
+ *
+ * ```gherkin
+ * When I set system time to "2020-02-02"
+ * ```
+ *
+ * @remarks
+ *
+ * A preceding step {@link When_I_use_fake_timers | "When I use fake timers"} is required. For example:
+ *
+ * ```gherkin
+ * When I use fake timers
+ *   And I set system time to "2020-02-02"
+ * ```
+ */
+export function When_I_set_system_time(now: number | string) {
+  if (typeof now === 'string') {
+    now = new Date(now).getTime();
+  }
+  cy.clock().invoke('setSystemTime', now);
+}
+
+When('I set system time to {int}', When_I_set_system_time);
+When('I set system time to {string}', When_I_set_system_time);


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(actions): add "When I set system time"

Inspired by:

- https://docs.cypress.io/api/commands/clock#Change-current-system-time
- https://jestjs.io/docs/jest-object#jestsetsystemtimenow-number--date

## What is the current behavior?

No step "When I set system time"

## What is the new behavior?

Step "When I set system time"

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation