### PR TITLE
feat(actions): add "When I advance timers by milliseconds" & "When I advance timers by seconds"

### DIFF
--- a/cypress/e2e/cypress/example.feature
+++ b/cypress/e2e/cypress/example.feature
@@ -171,6 +171,10 @@ Feature: Cypress example
       And I set system time to "2020-02-02"
       And I click on text "Click for current time!"
     Then I see text "1580601600"
-    When I use real timers
+    When I advance timers by 300 milliseconds
+      And I advance timers by 1 millisecond
+      And I advance timers by 3 seconds
+      And I advance timers by 1 second
+      And I use real timers
       And I click on text "Click for current time!"
     Then I do not see text "15806016000"

--- a/src/actions/timer.ts
+++ b/src/actions/timer.ts
@@ -31,6 +31,7 @@ import { When } from '@badeball/cypress-cucumber-preprocessor';
  *
  * - {@link When_I_use_real_timers | When I use real timers}
  * - {@link When_I_set_system_time | When I set system time}
+ * - {@link When_I_advance_timers_by_milliseconds | When I advance timers by milliseconds}
  */
 export function When_I_use_fake_timers() {
   cy.clock();
@@ -109,3 +110,48 @@ export function When_I_set_system_time(now: number | string) {
 
 When('I set system time to {int}', When_I_set_system_time);
 When('I set system time to {string}', When_I_set_system_time);
+
+/**
+ * When I advance timers by milliseconds:
+ *
+ * ```gherkin
+ * When I advance timers by {int} milliseconds
+ * ```
+ *
+ * Moves the clock the specified number of `milliseconds`. Any timers within the affected range of time will be called.
+ *
+ * @example
+ *
+ * Tick the clock time by 300 milliseconds:
+ *
+ * ```gherkin
+ * When I advance timers by 300 milliseconds
+ * ```
+ *
+ * Tick the clock time by 1 millisecond:
+ *
+ * ```gherkin
+ * When I advance timers by 1 millisecond
+ * ```
+ *
+ * @remarks
+ *
+ * A preceding step {@link When_I_use_fake_timers | "When I use fake timers"} is required. For example:
+ *
+ * ```gherkin
+ * When I use fake timers
+ *   And I advance timers by 300 milliseconds
+ * ```
+ */
+export function When_I_advance_timers_by_milliseconds(milliseconds: number) {
+  cy.tick(milliseconds);
+}
+
+When(
+  'I advance timers by {int} milliseconds',
+  When_I_advance_timers_by_milliseconds
+);
+When(
+  'I advance timers by {int} millisecond',
+  When_I_advance_timers_by_milliseconds
+);

--- a/src/actions/timer.ts
+++ b/src/actions/timer.ts
@@ -32,6 +32,7 @@ import { When } from '@badeball/cypress-cucumber-preprocessor';
  * - {@link When_I_use_real_timers | When I use real timers}
  * - {@link When_I_set_system_time | When I set system time}
  * - {@link When_I_advance_timers_by_milliseconds | When I advance timers by milliseconds}
+ * - {@link When_I_advance_timers_by_seconds | When I advance timers by seconds}
  */
 export function When_I_use_fake_timers() {
   cy.clock();
@@ -142,6 +143,10 @@ When('I set system time to {string}', When_I_set_system_time);
  * When I use fake timers
  *   And I advance timers by 300 milliseconds
  * ```
+ *
+ * @see
+ *
+ * - {@link When_I_advance_timers_by_seconds | When I advance timers by seconds}
  */
 export function When_I_advance_timers_by_milliseconds(milliseconds: number) {
   cy.tick(milliseconds);
@@ -155,3 +160,46 @@ When(
   'I advance timers by {int} millisecond',
   When_I_advance_timers_by_milliseconds
 );
+
+/**
+ * When I advance timers by seconds:
+ *
+ * ```gherkin
+ * When I advance timers by {int} seconds
+ * ```
+ *
+ * Moves the clock the specified number of `seconds`. Any timers within the affected range of time will be called.
+ *
+ * @example
+ *
+ * Tick the clock time by 3 seconds:
+ *
+ * ```gherkin
+ * When I advance timers by 3 seconds
+ * ```
+ *
+ * Tick the clock time by 1 second:
+ *
+ * ```gherkin
+ * When I advance timers by 1 second
+ * ```
+ *
+ * @remarks
+ *
+ * A preceding step {@link When_I_use_fake_timers | "When I use fake timers"} is required. For example:
+ *
+ * ```gherkin
+ * When I use fake timers
+ *   And I advance timers by 3 seconds
+ * ```
+ *
+ * @see
+ *
+ * - {@link When_I_advance_timers_by_milliseconds | When I advance timers by milliseconds}
+ */
+export function When_I_advance_timers_by_seconds(seconds: number) {
+  cy.tick(seconds * 1000);
+}
+
+When('I advance timers by {int} seconds', When_I_advance_timers_by_seconds);
+When('I advance timers by {int} second', When_I_advance_timers_by_seconds);


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(actions): add "When I advance timers by milliseconds" & "When I advance timers by seconds"

Inspired by:

- https://docs.cypress.io/api/commands/tick
- https://jestjs.io/docs/timer-mocks#advance-timers-by-time

## What is the current behavior?

No steps:

- When I advance timers by milliseconds
- When I advance timers by seconds

## What is the new behavior?

Steps:

- When I advance timers by milliseconds
- When I advance timers by seconds

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation