### PR TITLE
feat(actions): pass options to "When I type"

### DIFF
--- a/cypress/e2e/cypress/example.feature
+++ b/cypress/e2e/cypress/example.feature
@@ -22,7 +22,7 @@ Feature: Cypress example
     When I click on button "Click to toggle popover"
     Then I see text "This popover shows up on click"
 
-  Scenario: See and click label
+  Scenario: See, click, and type label
     Given I visit "https://example.cypress.io/commands/actions"
     Then I see label "Email address"
     When I click on label "Email address"
@@ -59,6 +59,15 @@ Feature: Cypress example
     Given I visit "https://example.cypress.io/commands/actions"
       And I get element by label text "Email address"
       And I type "user@example.com"
+        | animationDistanceThreshold | 5 |
+        | delay | 10 |
+        | force | false |
+        | log | true |
+        | parseSpecialCharSequences | true |
+        | release | true |
+        | scrollBehavior | top |
+        | timeout | 4000 |
+        | waitForAnimations | true |
     When I find element by placeholder text "Password"
       And I type "password"
       And I clear

--- a/src/actions/type.ts
+++ b/src/actions/type.ts
@@ -1,6 +1,6 @@
-import { When } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
 
-import { getCypressElement } from '../utils';
+import { getCypressElement, getOptions } from '../utils';
 
 /**
  * When I clear:
@@ -49,6 +49,21 @@ When('I clear', When_I_clear);
  * When I type "Hello, world!"
  * ```
  *
+ * [Options](https://docs.cypress.io/api/commands/type#Arguments):
+ *
+ * ```gherkin
+ * When I type "Hello, world!"
+ *   | animationDistanceThreshold | 5 |
+ *   | delay | 10 |
+ *   | force | false |
+ *   | log | true |
+ *   | parseSpecialCharSequences | true |
+ *   | release | true |
+ *   | scrollBehavior | top |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
+ * ```
+ *
  * @remarks
  *
  * A preceding step like {@link When_I_find_element_by_label_text | "When I find element by label text"} is required. For example:
@@ -65,8 +80,8 @@ When('I clear', When_I_clear);
  * When I type "{enter}"
  * ```
  */
-export function When_I_type(text: string) {
-  getCypressElement().type(text);
+export function When_I_type(text: string, options?: DataTable) {
+  getCypressElement().type(text, getOptions(options));
 }
 
 When('I type {string}', When_I_type);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './element';
 export * from './label';
+export * from './options';
 export * from './string';

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -1,0 +1,26 @@
+import { DataTable } from '@badeball/cypress-cucumber-preprocessor';
+
+/**
+ * Transforms table to options.
+ *
+ * @param table - Table.
+ * @returns - Options.
+ */
+export function getOptions(table?: DataTable) {
+  if (!table) {
+    return;
+  }
+
+  return Object.entries(table.rowsHash()).reduce((result, [key, value]) => {
+    if (value === 'true') {
+      result[key] = true;
+    } else if (value === 'false') {
+      result[key] = false;
+    } else if (!isNaN(Number(value))) {
+      result[key] = Number(value);
+    } else {
+      result[key] = value;
+    }
+    return result;
+  }, {} as Record<string, string | number | boolean>);
+}


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(actions): pass options to "When I type"

https://docs.cypress.io/api/commands/type#Arguments

## What is the current behavior?

No way to pass options to "When I type"

## What is the new behavior?

Pass options to "When I type" using [DataTable](https://github.com/badeball/cypress-cucumber-preprocessor/blob/master/docs/cucumber-basics.md#arguments)

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation