### PR TITLE
feat(assertions): add "Then I see textarea has value" & "Then I see textarea has value containing"

### DIFF
--- a/cypress/e2e/cypress/example.feature
+++ b/cypress/e2e/cypress/example.feature
@@ -170,14 +170,15 @@ Feature: Cypress example
       And I submit
     Then I see text "Your form has been submitted!"
 
-  Scenario: Get children
+  Scenario: Get children and assert textarea value
     Given I visit "https://example.cypress.io/commands/misc"
     When I find form
       And I get children
       And I get last element
       And I click
       And I type "children"
-    Then I find textarea by display value "children"
+    Then I see textarea has value "children"
+      And I see textarea has value containing "child"
 
   Scenario: Timers
     Given I visit "https://example.cypress.io/commands/spies-stubs-clocks"

--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -8,4 +8,5 @@ export * from './length';
 export * from './link';
 export * from './text';
 export * from './url';
+export * from './value';
 export * from './visible';

--- a/src/assertions/value.ts
+++ b/src/assertions/value.ts
@@ -1,0 +1,22 @@
+import { Then } from '@badeball/cypress-cucumber-preprocessor';
+
+/**
+ * Then I see textarea has value:
+ *
+ * ```gherkin
+ * Then I see textarea has value {string}
+ * ```
+ *
+ * Assert textarea with exact value is **_visible_** in the screen.
+ *
+ * @example
+ *
+ * ```gherkin
+ * Then I see textarea has value "Value"
+ * ```
+ */
+export function Then_I_see_textarea_has_value(value: string) {
+  cy.get('textarea:visible').invoke('val').should('eq', value);
+}
+
+Then('I see textarea has value {string}', Then_I_see_textarea_has_value);

--- a/src/assertions/value.ts
+++ b/src/assertions/value.ts
@@ -14,9 +14,41 @@ import { Then } from '@badeball/cypress-cucumber-preprocessor';
  * ```gherkin
  * Then I see textarea has value "Value"
  * ```
+ *
+ * @see
+ *
+ * - {@link Then_I_see_textarea_has_value_containing | Then I see textarea has value containing }
  */
 export function Then_I_see_textarea_has_value(value: string) {
   cy.get('textarea:visible').invoke('val').should('eq', value);
 }
 
 Then('I see textarea has value {string}', Then_I_see_textarea_has_value);
+
+/**
+ * Then I see textarea has value containing:
+ *
+ * ```gherkin
+ * Then I see textarea has value containing {string}
+ * ```
+ *
+ * Assert textarea with partial value is **_visible_** in the screen.
+ *
+ * @example
+ *
+ * ```gherkin
+ * Then I see textarea has value containing "Value"
+ * ```
+ *
+ * @see
+ *
+ * - {@link Then_I_see_textarea_has_value | Then I see textarea has value }
+ */
+export function Then_I_see_textarea_has_value_containing(value: string) {
+  cy.get('textarea:visible').invoke('val').should('include', value);
+}
+
+Then(
+  'I see textarea has value containing {string}',
+  Then_I_see_textarea_has_value_containing
+);


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(assertions): add "Then I see textarea has value" & "Then I see textarea has value containing"

## What is the current behavior?

No steps to assert textarea value

## What is the new behavior?

Steps to assert textarea value

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation