### PR TITLE
feat(assertions): add "Then I see input has value" & "Then I see input has value containing"

### DIFF
--- a/cypress/e2e/cypress/example.feature
+++ b/cypress/e2e/cypress/example.feature
@@ -180,6 +180,13 @@ Feature: Cypress example
     Then I see textarea has value "children"
       And I see textarea has value containing "child"
 
+  Scenario: Assert input value
+    Given I visit "https://example.cypress.io/commands/misc"
+    When I find element by label text "Name"
+      And I type "John Smith"
+    Then I see input has value "John Smith"
+      And I see input has value containing "John"
+
   Scenario: Timers
     Given I visit "https://example.cypress.io/commands/spies-stubs-clocks"
     When I use fake timers

--- a/src/assertions/value.ts
+++ b/src/assertions/value.ts
@@ -14,12 +14,44 @@ import { Then } from '@badeball/cypress-cucumber-preprocessor';
  * ```gherkin
  * Then I see input has value "Value"
  * ```
+ *
+ * @see
+ *
+ * - {@link Then_I_see_input_has_value_containing | Then I see input has value containing }
  */
 export function Then_I_see_input_has_value(value: string) {
   cy.get('input:visible').invoke('val').should('eq', value);
 }
 
 Then('I see input has value {string}', Then_I_see_input_has_value);
+
+/**
+ * Then I see input has value containing:
+ *
+ * ```gherkin
+ * Then I see input has value containing {string}
+ * ```
+ *
+ * Assert input with partial value is **_visible_** in the screen.
+ *
+ * @example
+ *
+ * ```gherkin
+ * Then I see input has value containing "Value"
+ * ```
+ *
+ * @see
+ *
+ * - {@link Then_I_see_input_has_value | Then I see input has value}
+ */
+export function Then_I_see_input_has_value_containing(value: string) {
+  cy.get('input:visible').invoke('val').should('include', value);
+}
+
+Then(
+  'I see input has value containing {string}',
+  Then_I_see_input_has_value_containing
+);
 
 /**
  * Then I see textarea has value:
@@ -63,7 +95,7 @@ Then('I see textarea has value {string}', Then_I_see_textarea_has_value);
  *
  * @see
  *
- * - {@link Then_I_see_textarea_has_value | Then I see textarea has value }
+ * - {@link Then_I_see_textarea_has_value | Then I see textarea has value}
  */
 export function Then_I_see_textarea_has_value_containing(value: string) {
   cy.get('textarea:visible').invoke('val').should('include', value);

--- a/src/assertions/value.ts
+++ b/src/assertions/value.ts
@@ -1,6 +1,27 @@
 import { Then } from '@badeball/cypress-cucumber-preprocessor';
 
 /**
+ * Then I see input has value:
+ *
+ * ```gherkin
+ * Then I see input has value {string}
+ * ```
+ *
+ * Assert input with exact value is **_visible_** in the screen.
+ *
+ * @example
+ *
+ * ```gherkin
+ * Then I see input has value "Value"
+ * ```
+ */
+export function Then_I_see_input_has_value(value: string) {
+  cy.get('input:visible').invoke('val').should('eq', value);
+}
+
+Then('I see input has value {string}', Then_I_see_input_has_value);
+
+/**
  * Then I see textarea has value:
  *
  * ```gherkin


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(assertions): add "Then I see input has value" & "Then I see input has value containing"

## What is the current behavior?

No steps to assert input value

## What is the new behavior?

Steps to assert input value

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation