### PR TITLE
feat(actions): add "When I intercept URL" & "When I intercept URL and stub body"

### DIFF
--- a/cypress/e2e/cypress/example.feature
+++ b/cypress/e2e/cypress/example.feature
@@ -204,3 +204,25 @@ Feature: Cypress example
       And I use real timers
       And I click on text "Click for current time!"
     Then I do not see text "15806016000"
+
+  Scenario: Intercept network requests
+    Given I visit "https://example.cypress.io/commands/network-requests"
+    When I intercept URL "/comments/1" and stub body '{"body":"Test 1"}'
+      And I click on button "Get Comment"
+    Then I see text "Test 1"
+    When I intercept URL "/comments/1"
+      | auth | {"username":"user","password":"pass"} |
+      | body | {"body":"Test 2"} |
+      | headers | {"X-Requested-With":"exampleClient"} |
+      | hostname | localhost |
+      | https | true |
+      | method | GET |
+      | middleware | false |
+      | path | /api/commands/intercept?foo=bar |
+      | pathname | /api/commands/intercept |
+      | port | 8080 |
+      | query | {"foo":"bar"} |
+      | resourceType | fetch |
+      | times | 1 |
+      And I click on button "Get Comment"
+    Then I see text "Test 2"

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -6,6 +6,7 @@ export * from './debug';
 export * from './double-click';
 export * from './focus';
 export * from './go';
+export * from './intercept';
 export * from './local-storage';
 export * from './log';
 export * from './pause';

--- a/src/actions/intercept.ts
+++ b/src/actions/intercept.ts
@@ -1,0 +1,115 @@
+import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
+
+import { getOptions } from '../utils';
+
+/**
+ * When I intercept URL:
+ *
+ * ```gherkin
+ * When I intercept URL {string}
+ * ```
+ *
+ * Stub [network requests](https://docs.cypress.io/guides/guides/network-requests) and responses.
+ *
+ * @example
+ *
+ * Intercept HTTP request and stub response body:
+ *
+ * ```gherkin
+ * When I intercept URL "/api/users/1"
+ *   | body | {"name":"Mark"} |
+ * ```
+ *
+ * With [routeMatcher](https://docs.cypress.io/api/commands/intercept#Icon-nameangle-right--routeMatcher-RouteMatcher) options:
+ *
+ * ```gherkin
+ * When I intercept URL "/api/users/1"
+ *   | auth | {"username":"user","password":"pass"} |
+ *   | body | {"name":"Mark"} |
+ *   | headers | {"X-Requested-With":"exampleClient"} |
+ *   | hostname | localhost |
+ *   | https | true |
+ *   | method | GET |
+ *   | middleware | false |
+ *   | path | /api/commands/intercept?foo=bar |
+ *   | pathname | /api/commands/intercept |
+ *   | port | 8080 |
+ *   | query | {"foo":"bar"} |
+ *   | resourceType | fetch |
+ *   | times | 1 |
+ * ```
+ *
+ * [routeMatcher](https://docs.cypress.io/api/commands/intercept#Icon-nameangle-right--routeMatcher-RouteMatcher) options:
+ *
+ * | Option | Description |
+ * | --- | --- |
+ * | auth | HTTP Basic Authentication (`object` with keys `username` and `password`) |
+ * | body | HTTP response body (`object` or `string`) |
+ * | headers | HTTP request headers (`object`) |
+ * | hostname | HTTP request hostname |
+ * | https | `true`: only secure (https://) requests, `false`: only insecure (http://) requests |
+ * | method | HTTP request method (matches any method by default) |
+ * | middleware | `true`: match route first and in defined order, `false`: match route in reverse order (default) |
+ * | path | HTTP request path after the hostname, including query parameters |
+ * | pathname | Like path, but without query parameters |
+ * | port | HTTP request port(s) (`number` or `Array`) |
+ * | query | Parsed query string (`object`) |
+ * | resourceType | The resource type of the request. See ["Request object properties"](https://docs.cypress.io/api/commands/intercept#Request-object-properties) for a list of possible values for resourceType. |
+ * | times | Maximum number of times to match (number) |
+ *
+ * @remarks
+ *
+ * All intercepts are automatically cleared before every test.
+ *
+ * @see
+ *
+ * - {@link When_I_intercept_URL_and_stub_body | When I intercept URL and stub body}
+ */
+export function When_I_intercept_URL(url: string, routeMatcher?: DataTable) {
+  cy.intercept(url, getOptions(routeMatcher) as object);
+}
+
+When('I intercept URL {string}', When_I_intercept_URL);
+
+/**
+ * When I intercept URL and stub body:
+ *
+ * ```gherkin
+ * When I intercept URL {string} and stub body {string}
+ * ```
+ *
+ * @example
+ *
+ * Intercept HTTP request and stub body with JSON:
+ *
+ * ```gherkin
+ * When I intercept URL "/api/users/1" and stub body '{"name":"Mark"}'
+ * ```
+ *
+ * Intercept HTTP request and stub body with text:
+ *
+ * ```gherkin
+ * When I intercept URL "/page" and stub body "Text"
+ * ```
+ *
+ * @remarks
+ *
+ * All intercepts are automatically cleared before every test.
+ *
+ * @see
+ *
+ * - {@link When_I_intercept_URL | When I intercept URL}
+ */
+export function When_I_intercept_URL_and_stub_body(url: string, body: string) {
+  try {
+    body = JSON.parse(body);
+  } catch (error) {
+    // pass
+  }
+  cy.intercept(url, { body });
+}
+
+When(
+  'I intercept URL {string} and stub body {string}',
+  When_I_intercept_URL_and_stub_body
+);


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(actions): add "When I intercept URL" & "When I intercept URL and stub body"

https://docs.cypress.io/api/commands/intercept

## What is the current behavior?

No step definition to intercept URL and stub body

## What is the new behavior?

Step definitions to intercept HTTP request and stub body

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation