### PR TITLE
feat(actions): add "When I select file"

### DIFF
--- a/cypress/e2e/dropzone/dropzone.feature
+++ b/cypress/e2e/dropzone/dropzone.feature
@@ -1,0 +1,17 @@
+Feature: Dropzone
+  Scenario: Select file
+    Given I visit "https://www.dropzone.dev/"
+    When I get element by selector "input[type=file]"
+      And I select file "cypress/fixtures/example.json"
+        | force | true |
+    Then I see text "0.2 KB"
+      And I see text "example.json"
+
+  Scenario: Drag and drop file
+    Given I visit "https://www.dropzone.dev/"
+    When I get element by selector "input[type=file]"
+      And I select file "cypress/fixtures/example.json"
+        | action | drag-drop |
+        | force | true |
+    Then I see text "0.2 KB"
+      And I see text "example.json"

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -16,6 +16,7 @@ export * from './right-click';
 export * from './screenshot';
 export * from './scroll';
 export * from './select';
+export * from './select-file';
 export * from './session-storage';
 export * from './submit';
 export * from './timer';

--- a/src/actions/select-file.ts
+++ b/src/actions/select-file.ts
@@ -1,0 +1,49 @@
+import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
+
+import { getCypressElement, getOptions } from '../utils';
+
+/**
+ * When I select file:
+ *
+ * ```gherkin
+ * When I select file {string}
+ * ```
+ *
+ * Selects a file in an HTML5 input element.
+ *
+ * @example
+ *
+ * Select file:
+ *
+ * ```gherkin
+ * When I select file "cypress/fixtures/example.json"
+ * ```
+ *
+ * Drag and drop file:
+ *
+ * ```gherkin
+ * When I select file "cypress/fixtures/example.json"
+ *   | action | drag-drop |
+ * ```
+ *
+ * Force the action when input is not visible:
+ *
+ * ```gherkin
+ * When I select file "cypress/fixtures/example.json"
+ *   | force | true |
+ * ```
+ *
+ * @remarks
+ *
+ * A preceding step like {@link When_I_get_element_by_selector | "When I get element by selector"} is required. For example:
+ *
+ * ```gherkin
+ * When I get element by selector "input[type=file]"
+ *   And I select file "cypress/fixtures/example.json"
+ * ```
+ */
+export function When_I_select_file(file: string, options?: DataTable) {
+  getCypressElement().selectFile(file, getOptions(options));
+}
+
+When('I select file {string}', When_I_select_file);


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(actions): add "When I select file"

https://docs.cypress.io/api/commands/selectfile

## What is the current behavior?

No action to select or drag and drop file

## What is the new behavior?

Action to select or drag and drop file

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation