### PR TITLE
feat(actions): pass options to "When I visit URL"

### DIFF
--- a/cypress/e2e/google/google.feature
+++ b/cypress/e2e/google/google.feature
@@ -5,3 +5,8 @@ Feature: Google
       And I find element by title "Search"
       And I type "title{selectAll}{backspace}"
       And I type "title{enter}"
+
+  Scenario: Visit does not fail on status code
+    Given I visit "https://www.google.com/404"
+      | failOnStatusCode | false |
+    Then I see text "404"

--- a/src/actions/visit.ts
+++ b/src/actions/visit.ts
@@ -1,6 +1,7 @@
-import { When } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
 
-/* eslint-disable tsdoc/syntax */
+import { getOptions } from '../utils';
+
 /**
  * When I visit URL:
  *
@@ -22,20 +23,25 @@ import { When } from '@badeball/cypress-cucumber-preprocessor';
  * When I visit "/"
  * ```
  *
- * > Cypress [`baseUrl`](https://docs.cypress.io/guides/references/configuration#e2e) must be defined for relative URL.
+ * Cypress [`baseUrl`](https://docs.cypress.io/guides/references/configuration#e2e) must be defined for relative URL.
  *
  * @remarks
  *
- * If the page does not respond with a 200 status code, then this step will fail:
+ * If the page does not respond with a `2xx` status code, then this step will fail:
  *
  * ```gherkin
- * # fail
+ * When I visit "/404" # fail
+ * ```
+ *
+ * If you don't want status codes to cause failures, then pass the option:
+ *
+ * ```gherkin
  * When I visit "/404"
+ *   | failOnStatusCode | false |
  * ```
  */
-/* eslint-enable tsdoc/syntax */
-export function When_I_visit_URL(url: string) {
-  cy.visit(url);
+export function When_I_visit_URL(url: string, options?: DataTable) {
+  cy.visit(url, getOptions(options));
 }
 
 When('I visit {string}', When_I_visit_URL);


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(actions): pass options to "When I visit URL"

## What is the current behavior?

No way to set `failOnStatusCode: false` for visit

## What is the new behavior?

You can set `failOnStatusCode: false` for visit

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation