### PR TITLE
fix(utils): filter visible labels in `setCypressElementsByLabelText`

### DIFF
--- a/src/utils/label.ts
+++ b/src/utils/label.ts
@@ -3,6 +3,40 @@
 import { setCypressElement } from '../utils';
 
 /**
+ * Set Cypress elements by label text:
+ *
+ * ```ts
+ * setCypressElementsByLabelText('...');
+ * ```
+ *
+ * @example
+ *
+ * ```ts
+ * setCypressElementsByLabelText('Text');
+ * ```
+ *
+ * @see
+ *
+ * - {@link getCypressElement}
+ * - {@link setCypressElement}
+ *
+ * @param text - Label text.
+ * @returns - Cypress element.
+ *
+ * @private
+ */
+export function setCypressElementsByLabelText(text: string) {
+  const selector = [
+    `label:contains('${text}')`,
+    `[aria-labelledby='${text}']`,
+    `[aria-label='${text}']`,
+  ].join(',');
+  const elements = cy.get(selector).filter(':visible');
+  setCypressElement(elements);
+  return elements;
+}
+
+/**
  * Set Cypress element by label text:
  *
  * ```ts
@@ -12,7 +46,7 @@ import { setCypressElement } from '../utils';
  * @example
  *
  * ```ts
- * setCypressElementByLabelText('Label');
+ * setCypressElementByLabelText('Text');
  * ```
  *
  * @see
@@ -26,12 +60,8 @@ import { setCypressElement } from '../utils';
  * @private
  */
 export function setCypressElementByLabelText(text: string) {
-  const selector = [
-    `label:visible:contains('${text}')`,
-    `[aria-labelledby='${text}']`,
-    `[aria-label='${text}']`,
-  ].join(',');
-  const label = cy.get(selector).first();
-  setCypressElement(label);
-  return label;
+  const elements = setCypressElementsByLabelText(text);
+  const element = elements.first();
+  setCypressElement(element);
+  return element;
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(utils): filter visible labels in `setCypressElementsByLabelText`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation