### PR TITLE
fix(queries): find visible buttons and links

### DIFF
--- a/cypress/e2e/cypress/example.feature
+++ b/cypress/e2e/cypress/example.feature
@@ -109,9 +109,10 @@ Feature: Cypress example
       And I scroll window to "bottom-right"
       And I scroll window to "center"
       And I scroll window to "top-left"
-    When I find button by text "I'm Here"
-    Then I see element is not visible
-    When I scroll into view
+    Then I find element by text "I'm Here"
+      And I see element is not visible
+    When I get element by selector "#scroll-horizontal button"
+      And I scroll into view
     Then I see element is visible
 
   Scenario: Get nth element

--- a/src/queries/button.ts
+++ b/src/queries/button.ts
@@ -1,6 +1,6 @@
 import { When } from '@badeball/cypress-cucumber-preprocessor';
 
-import { setCypressElement } from '../utils';
+import { getCypressElement, setCypressElement } from '../utils';
 
 /**
  * When I find buttons by text:
@@ -30,7 +30,10 @@ import { setCypressElement } from '../utils';
  * - {@link When_I_find_button_by_text | When I find button by text}
  */
 export function When_I_find_buttons_by_text(text: string) {
-  setCypressElement(cy.get(`button:contains('${text}')`));
+  const selector = ['button', "[type='button']", "[type='submit']"]
+    .map((value) => `${value}:contains('${text}'):visible`)
+    .join(',');
+  setCypressElement(cy.get(selector));
 }
 
 When('I find buttons by text {string}', When_I_find_buttons_by_text);
@@ -64,7 +67,8 @@ When('I find buttons by text {string}', When_I_find_buttons_by_text);
  * - {@link When_I_find_buttons_by_text | When I find buttons by text}
  */
 export function When_I_find_button_by_text(text: string) {
-  setCypressElement(cy.contains('button', text));
+  When_I_find_buttons_by_text(text);
+  setCypressElement(getCypressElement().first());
 }
 
 When('I find button by text {string}', When_I_find_button_by_text);

--- a/src/queries/link.ts
+++ b/src/queries/link.ts
@@ -1,6 +1,6 @@
 import { When } from '@badeball/cypress-cucumber-preprocessor';
 
-import { setCypressElement } from '../utils';
+import { getCypressElement, setCypressElement } from '../utils';
 
 /**
  * When I find links by text:
@@ -30,7 +30,7 @@ import { setCypressElement } from '../utils';
  * - {@link When_I_find_link_by_text | When I find link by text}
  */
 export function When_I_find_links_by_text(text: string) {
-  setCypressElement(cy.get(`a:contains('${text}')`));
+  setCypressElement(cy.get(`a:contains('${text}'):visible`));
 }
 
 When('I find links by text {string}', When_I_find_links_by_text);
@@ -64,7 +64,8 @@ When('I find links by text {string}', When_I_find_links_by_text);
  * - {@link When_I_find_links_by_text | When I find links by text}
  */
 export function When_I_find_link_by_text(text: string) {
-  setCypressElement(cy.contains('a', text));
+  When_I_find_links_by_text(text);
+  setCypressElement(getCypressElement().first());
 }
 
 When('I find link by text {string}', When_I_find_link_by_text);


### PR DESCRIPTION
## What is the motivation for this pull request?

- fix(queries): find visible buttons in "When I find buttons by text"
- fix(queries): find visible links in "When I find links by text"

## What is the current behavior?

"When I find buttons by text" and "When I find button by text" don't filter by visible buttons and don't include additional button types

"When I find links by text" and "When I find link by text" don't filter by visible links

## What is the new behavior?

"When I find buttons by text" and "When I find button by text" filter by visible buttons and include additional button types

"When I find links by text" and "When I find link by text" filter by visible links

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation