### PR TITLE
fix(queries): escape string in steps

### DIFF
--- a/src/queries/alt-text.ts
+++ b/src/queries/alt-text.ts
@@ -35,7 +35,7 @@ import { getCypressElement, setCypressElement } from '../utils';
  * - {@link When_I_find_images_by_alt_text | When I find images by alt text}
  */
 export function When_I_find_elements_by_alt_text(altText: string) {
-  setCypressElement(cy.get(`[alt='${altText}']:visible`));
+  setCypressElement(cy.get(`[alt=${JSON.stringify(altText)}]:visible`));
 }
 
 When('I find elements by alt text {string}', When_I_find_elements_by_alt_text);

--- a/src/queries/heading.ts
+++ b/src/queries/heading.ts
@@ -31,7 +31,7 @@ import { getCypressElement, setCypressElement } from '../utils';
  */
 export function When_I_find_headings_by_text(text: string) {
   const selector = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
-    .map((tag) => `${tag}:contains('${text}'):visible`)
+    .map((tag) => `${tag}:contains(${JSON.stringify(text)}):visible`)
     .join(',');
   setCypressElement(cy.get(selector));
 }

--- a/src/queries/link.ts
+++ b/src/queries/link.ts
@@ -30,7 +30,7 @@ import { getCypressElement, setCypressElement } from '../utils';
  * - {@link When_I_find_link_by_text | When I find link by text}
  */
 export function When_I_find_links_by_text(text: string) {
-  setCypressElement(cy.get(`a:contains('${text}'):visible`));
+  setCypressElement(cy.get(`a:contains(${JSON.stringify(text)}):visible`));
 }
 
 When('I find links by text {string}', When_I_find_links_by_text);

--- a/src/queries/name.ts
+++ b/src/queries/name.ts
@@ -34,7 +34,7 @@ import { getCypressElement, setCypressElement } from '../utils';
  */
 /* eslint-enable tsdoc/syntax */
 export function When_I_find_elements_by_name(name: string) {
-  setCypressElement(cy.get(`[name='${name}']:visible`));
+  setCypressElement(cy.get(`[name=${JSON.stringify(name)}]:visible`));
 }
 
 When('I find elements by name {string}', When_I_find_elements_by_name);

--- a/src/queries/placeholder.ts
+++ b/src/queries/placeholder.ts
@@ -39,7 +39,9 @@ import { getCypressElement, setCypressElement } from '../utils';
 export function When_I_find_elements_by_placeholder_text(
   placeholderText: string,
 ) {
-  setCypressElement(cy.get(`[placeholder='${placeholderText}']:visible`));
+  setCypressElement(
+    cy.get(`[placeholder=${JSON.stringify(placeholderText)}]:visible`),
+  );
 }
 
 When(

--- a/src/queries/testid.ts
+++ b/src/queries/testid.ts
@@ -37,7 +37,9 @@ import { setCypressElement } from '../utils';
  */
 /* eslint-enable tsdoc/syntax */
 export function When_I_find_element_by_testid(testId: string) {
-  setCypressElement(cy.get(`[data-testid='${testId}']:visible`).first());
+  setCypressElement(
+    cy.get(`[data-testid=${JSON.stringify(testId)}]:visible`).first(),
+  );
 }
 
 When('I find element by test ID {string}', When_I_find_element_by_testid);

--- a/src/queries/title.ts
+++ b/src/queries/title.ts
@@ -30,8 +30,8 @@ import { setCypressElement } from '../utils';
  */
 export function When_I_find_element_by_title(title: string) {
   const selector = [
-    `svg title:contains('${title}')`,
-    `[title='${title}']`,
+    `svg title:contains(${JSON.stringify(title)})`,
+    `[title=${JSON.stringify(title)}]`,
   ].join(',');
   setCypressElement(cy.get(selector).first());
 }

--- a/src/utils/label.ts
+++ b/src/utils/label.ts
@@ -27,9 +27,9 @@ import { setCypressElement } from '../utils';
  */
 export function setCypressElementsByLabelText(text: string) {
   const selector = [
-    `label:contains('${text}')`,
-    `[aria-labelledby='${text}']`,
-    `[aria-label='${text}']`,
+    `label:contains(${JSON.stringify(text)})`,
+    `[aria-labelledby=${JSON.stringify(text)}]`,
+    `[aria-label=${JSON.stringify(text)}]`,
   ].join(',');
   const elements = cy.get(selector).filter(':visible');
   setCypressElement(elements);


### PR DESCRIPTION
## What is the motivation for this pull request?

Escape string argument in steps:

- When I find elements by alt text
- When I find headings by text
- When I find links by text
- When I find elements by name
- When I find elements by placeholder text
- When I find element by test ID
- When I find element by title
- Label steps

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation