### PR TITLE
fix(queries): fix label logic in "When I find input by label text"

### DIFF
--- a/src/queries/input.ts
+++ b/src/queries/input.ts
@@ -1,10 +1,6 @@
 import { When } from '@badeball/cypress-cucumber-preprocessor';
 
-import {
-  When_I_find_element_by_label_text,
-  When_I_get_element_by_selector,
-} from '../queries';
-import { getCypressElement, setCypressElement } from '../utils';
+import { getByLabelText, setCypressElement } from '../utils';
 
 /**
  * When I find input by label text:
@@ -37,17 +33,7 @@ import { getCypressElement, setCypressElement } from '../utils';
  * - {@link When_I_find_element_by_label_text | When I find element by label text }
  */
 export function When_I_find_input_by_label_text(text: string) {
-  When_I_find_element_by_label_text(text);
-  const label = getCypressElement();
-
-  label.invoke('attr', 'for').then((forValue) => {
-    if (forValue) {
-      When_I_get_element_by_selector(`#${forValue}`);
-    } else {
-      When_I_find_element_by_label_text(text);
-      setCypressElement(getCypressElement().find('input').first());
-    }
-  });
+  setCypressElement(getByLabelText('input', text));
 }
 
 When('I find input by label text {string}', When_I_find_input_by_label_text);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './display-value';
 export * from './element';
+export * from './label';
 export * from './options';
 export * from './string';

--- a/src/utils/label.ts
+++ b/src/utils/label.ts
@@ -1,0 +1,42 @@
+/* eslint-disable tsdoc/syntax */
+
+import { When_I_find_element_by_label_text } from '../queries';
+import { getCypressElement } from './element';
+
+/**
+ * Get first Cypress element by label text.
+ *
+ * @param element - Element name.
+ * @param text - Label text.
+ * @returns - Cypress element.
+ * @private
+ */
+export function getByLabelText(element: 'input' | 'textarea', text: string) {
+  When_I_find_element_by_label_text(text);
+
+  return getCypressElement().then(($element: Cypress.JQueryWithSelector) => {
+    const tagName = $element.prop('tagName').toLowerCase();
+
+    // https://developer.mozilla.org/docs/Web/HTML/Element/label
+    if (tagName === 'label') {
+      const forValue = $element.attr('for');
+      if (forValue) {
+        return cy.get(`#${forValue}`);
+      } else {
+        return $element.find(element).first();
+      }
+    }
+
+    // https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby
+    if ($element.attr('aria-labelledby') === text) {
+      return cy.get(`#${text}`);
+    }
+
+    // https://developer.mozilla.org/docs/Web/Accessibility/ARIA/Attributes/aria-label
+    if (tagName === element && $element.attr('aria-label') === text) {
+      return $element;
+    }
+
+    throw new Error(`Unable to get ${element} by label text: ${text}`);
+  });
+}


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(queries): fix label logic in "When I find input by label text"

## What is the current behavior?

Label options not handled:

- aria-labelledby
- aria-label

## What is the new behavior?

Handle label options:

- aria-labelledby
- aria-label

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation