### PR TITLE
feat(assertions): pass options to "Then I see document title" and "Then I see document title contains"

### DIFF
--- a/cypress/e2e/example/example.feature
+++ b/cypress/e2e/example/example.feature
@@ -2,7 +2,11 @@ Feature: Example
   Scenario: See document title
     Given I visit "http://example.com/"
     Then I see document title "Example Domain"
+      | log | true |
+      | timeout | 0 |
       And I see document title contains "Example"
+        | log | true |
+        | timeout | 0 |
 
   Scenario: Heading
     Given I visit "http://example.com/"

--- a/src/assertions/document-title.ts
+++ b/src/assertions/document-title.ts
@@ -50,12 +50,23 @@ Then('I see document title {string}', Then_I_see_document_title);
  * Then I see document title contains "Title"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/title#Arguments):
+ *
+ * ```gherkin
+ * Then I see document title contains "Title"
+ *   | log | true |
+ *   | timeout | 4000 |
+ * ```
+ *
  * @see
  *
  * - {@link Then_I_see_document_title | Then I see document title}
  */
-export function Then_I_see_document_title_contains(title: string) {
-  cy.title().should('contain', title);
+export function Then_I_see_document_title_contains(
+  title: string,
+  options?: DataTable,
+) {
+  cy.title(getOptions(options)).should('contain', title);
 }
 
 Then(

--- a/src/assertions/document-title.ts
+++ b/src/assertions/document-title.ts
@@ -1,4 +1,6 @@
-import { Then } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, Then } from '@badeball/cypress-cucumber-preprocessor';
+
+import { getOptions } from '../utils';
 
 /**
  * Then I see document title:
@@ -15,12 +17,20 @@ import { Then } from '@badeball/cypress-cucumber-preprocessor';
  * Then I see document title "Title"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/title#Arguments):
+ *
+ * ```gherkin
+ * Then I see document title "Title"
+ *   | log | true |
+ *   | timeout | 4000 |
+ * ```
+ *
  * @see
  *
  * - {@link Then_I_see_document_title_contains | Then I see document title contains}
  */
-export function Then_I_see_document_title(title: string) {
-  cy.title().should('equal', title);
+export function Then_I_see_document_title(title: string, options?: DataTable) {
+  cy.title(getOptions(options)).should('equal', title);
 }
 
 Then('I see document title {string}', Then_I_see_document_title);


### PR DESCRIPTION
## What is the motivation for this pull request?

- feat(assertions): pass options to "Then I see document title"
- feat(assertions): pass options to "Then I see document title contains"

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation