### PR TITLE
feat: pass options to steps

### DIFF
--- a/src/actions/blur.ts
+++ b/src/actions/blur.ts
@@ -1,4 +1,6 @@
-import { When } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
+
+import { getOptions } from '../utils';
 
 /**
  * When I blur:
@@ -15,6 +17,15 @@ import { When } from '@badeball/cypress-cucumber-preprocessor';
  * When I blur
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/blur#Arguments):
+ *
+ * ```gherkin
+ * When I blur
+ *   | log | true |
+ *   | force | false |
+ *   | timeout | 4000 |
+ * ```
+ *
  * @remarks
  *
  * A preceding step like {@link When_I_find_input_by_label_text | "When I find input by label text"} is required. For example:
@@ -24,8 +35,8 @@ import { When } from '@badeball/cypress-cucumber-preprocessor';
  *   And I blur
  * ```
  */
-export function When_I_blur() {
-  cy.focused().blur();
+export function When_I_blur(options?: DataTable) {
+  cy.focused().blur(getOptions(options));
 }
 
 When('I blur', When_I_blur);

--- a/src/actions/clear.ts
+++ b/src/actions/clear.ts
@@ -1,0 +1,49 @@
+import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
+
+import { getCypressElement, getOptions } from '../utils';
+
+/**
+ * When I clear:
+ *
+ * ```gherkin
+ * When I clear
+ * ```
+ *
+ * Alias for {@link When_I_type | "When I type"}:
+ *
+ * ```gherkin
+ * When I type "{selectall}{backspace}"
+ * ```
+ *
+ * @example
+ *
+ * ```gherkin
+ * When I clear
+ * ```
+ *
+ * With [options](https://docs.cypress.io/api/commands/clear#Arguments):
+ *
+ * ```gherkin
+ * When I clear
+ *   | animationDistanceThreshold | 5 |
+ *   | force | false |
+ *   | log | true |
+ *   | scrollBehavior | top |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
+ * ```
+ *
+ * @remarks
+ *
+ * A preceding step like {@link When_I_find_element_by_label_text | "When I find element by label text"} is required. For example:
+ *
+ * ```gherkin
+ * When I find element by label text "Input"
+ *   And I clear
+ * ```
+ */
+export function When_I_clear(options?: DataTable) {
+  getCypressElement().clear(getOptions(options));
+}
+
+When('I clear', When_I_clear);

--- a/src/actions/click.ts
+++ b/src/actions/click.ts
@@ -118,12 +118,29 @@ When('I click on button {string}', When_I_click_on_button);
  * When I click on link "Link"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/click#Arguments):
+ *
+ * ```gherkin
+ * When I click on link "Link"
+ *   | altKey | false |
+ *   | animationDistanceThreshold | 5 |
+ *   | ctrlKey | false |
+ *   | log | true |
+ *   | force | false |
+ *   | metaKey | false |
+ *   | multiple | false |
+ *   | scrollBehavior | top |
+ *   | shiftKey | false |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
+ * ```
+ *
  * @see
  *
  * - {@link When_I_click_on_text | When I click on text}
  */
-export function When_I_click_on_link(text: string) {
-  cy.contains('a', text).first().click();
+export function When_I_click_on_link(text: string, options?: DataTable) {
+  cy.contains('a', text).first().click(getOptions(options));
 }
 
 When('I click on link {string}', When_I_click_on_link);

--- a/src/actions/click.ts
+++ b/src/actions/click.ts
@@ -204,13 +204,30 @@ When('I click on text {string}', When_I_click_on_text);
  * When I click on label "Label"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/click#Arguments):
+ *
+ * ```gherkin
+ * When I click on label "Label"
+ *   | altKey | false |
+ *   | animationDistanceThreshold | 5 |
+ *   | ctrlKey | false |
+ *   | log | true |
+ *   | force | false |
+ *   | metaKey | false |
+ *   | multiple | false |
+ *   | scrollBehavior | top |
+ *   | shiftKey | false |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
+ * ```
+ *
  * @see
  *
  * - {@link When_I_click_on_text | When I click on text}
  */
-export function When_I_click_on_label(text: string) {
+export function When_I_click_on_label(text: string, options?: DataTable) {
   When_I_find_element_by_label_text(text);
-  getCypressElement().click();
+  getCypressElement().click(getOptions(options));
 }
 
 When('I click on label {string}', When_I_click_on_label);

--- a/src/actions/click.ts
+++ b/src/actions/click.ts
@@ -75,13 +75,30 @@ When('I click', When_I_click);
  * When I click on button "Button"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/click#Arguments):
+ *
+ * ```gherkin
+ * When I click on button "Button"
+ *   | altKey | false |
+ *   | animationDistanceThreshold | 5 |
+ *   | ctrlKey | false |
+ *   | log | true |
+ *   | force | false |
+ *   | metaKey | false |
+ *   | multiple | false |
+ *   | scrollBehavior | top |
+ *   | shiftKey | false |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
+ * ```
+ *
  * @see
  *
  * - {@link When_I_click_on_text | When I click on text}
  */
-export function When_I_click_on_button(text: string) {
+export function When_I_click_on_button(text: string, options?: DataTable) {
   When_I_find_button_by_text(text);
-  getCypressElement().click();
+  getCypressElement().click(getOptions(options));
 }
 
 When('I click on button {string}', When_I_click_on_button);

--- a/src/actions/click.ts
+++ b/src/actions/click.ts
@@ -162,14 +162,31 @@ When('I click on link {string}', When_I_click_on_link);
  * When I click on text "Text"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/click#Arguments):
+ *
+ * ```gherkin
+ * When I click on text "Text"
+ *   | altKey | false |
+ *   | animationDistanceThreshold | 5 |
+ *   | ctrlKey | false |
+ *   | log | true |
+ *   | force | false |
+ *   | metaKey | false |
+ *   | multiple | false |
+ *   | scrollBehavior | top |
+ *   | shiftKey | false |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
+ * ```
+ *
  * @see
  *
  * - {@link When_I_click_on_button | When I click on button}
  * - {@link When_I_click_on_label | When I click on label}
  * - {@link When_I_click_on_link | When I click on link}
  */
-export function When_I_click_on_text(text: string) {
-  cy.contains(text).click();
+export function When_I_click_on_text(text: string, options?: DataTable) {
+  cy.contains(text).click(getOptions(options));
 }
 
 When('I click on text {string}', When_I_click_on_text);

--- a/src/actions/click.ts
+++ b/src/actions/click.ts
@@ -1,10 +1,10 @@
-import { When } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
 
 import {
   When_I_find_button_by_text,
   When_I_find_element_by_label_text,
 } from '../queries';
-import { getCypressElement } from '../utils';
+import { getCypressElement, getOptions } from '../utils';
 
 /**
  * When I click:
@@ -23,6 +23,23 @@ import { getCypressElement } from '../utils';
  * When I click
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/click#Arguments):
+ *
+ * ```gherkin
+ * When I click
+ *   | altKey | false |
+ *   | animationDistanceThreshold | 5 |
+ *   | ctrlKey | false |
+ *   | log | true |
+ *   | force | false |
+ *   | metaKey | false |
+ *   | multiple | false |
+ *   | scrollBehavior | top |
+ *   | shiftKey | false |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
+ * ```
+ *
  * @remarks
  *
  * A preceding step like {@link When_I_find_element_by_text | "When I find element by text"} is required. For example:
@@ -37,8 +54,8 @@ import { getCypressElement } from '../utils';
  * - {@link When_I_double_click | When I double-click}
  * - {@link When_I_right_click | When I right-click}
  */
-export function When_I_click() {
-  getCypressElement().click();
+export function When_I_click(options?: DataTable) {
+  getCypressElement().click(getOptions(options));
 }
 
 When('I click', When_I_click);

--- a/src/actions/focus.ts
+++ b/src/actions/focus.ts
@@ -1,6 +1,6 @@
-import { When } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
 
-import { getCypressElement } from '../utils';
+import { getCypressElement, getOptions } from '../utils';
 
 /**
  * When I focus:
@@ -15,6 +15,14 @@ import { getCypressElement } from '../utils';
  * When I focus
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/focus#Arguments):
+ *
+ * ```gherkin
+ * When I focus
+ *   | log | true |
+ *   | timeout | 4000 |
+ * ```
+ *
  * @remarks
  *
  * A preceding step like {@link When_I_find_element_by_text | "When I find element by text"} is required. For example:
@@ -24,8 +32,8 @@ import { getCypressElement } from '../utils';
  *   And I focus
  * ```
  */
-export function When_I_focus() {
-  getCypressElement().focus();
+export function When_I_focus(options?: DataTable) {
+  getCypressElement().focus(getOptions(options));
 }
 
 When('I focus', When_I_focus);

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,4 +1,5 @@
 export * from './blur';
+export * from './clear';
 export * from './click';
 export * from './config';
 export * from './cookie';

--- a/src/actions/submit.ts
+++ b/src/actions/submit.ts
@@ -1,6 +1,6 @@
-import { When } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
 
-import { getCypressElement } from '../utils';
+import { getCypressElement, getOptions } from '../utils';
 
 /**
  * When I submit:
@@ -17,6 +17,14 @@ import { getCypressElement } from '../utils';
  * When I submit
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/submit#Arguments):
+ *
+ * ```gherkin
+ * When I submit
+ *   | log | true |
+ *   | timeout | 4000 |
+ * ```
+ *
  * @remarks
  *
  * A preceding step like {@link When_I_find_form | "When I find form"} is required. For example:
@@ -25,10 +33,9 @@ import { getCypressElement } from '../utils';
  * When I find form
  *   And I submit
  * ```
- *
  */
-export function When_I_submit() {
-  getCypressElement().submit();
+export function When_I_submit(options?: DataTable) {
+  getCypressElement().submit(getOptions(options));
 }
 
 When('I submit', When_I_submit);

--- a/src/actions/type.ts
+++ b/src/actions/type.ts
@@ -3,40 +3,6 @@ import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
 import { getCypressElement, getOptions } from '../utils';
 
 /**
- * When I clear:
- *
- * ```gherkin
- * When I clear
- * ```
- *
- * Alias for {@link When_I_type | "When I type"}:
- *
- * ```gherkin
- * When I type "{selectall}{backspace}"
- * ```
- *
- * @example
- *
- * ```gherkin
- * When I clear
- * ```
- *
- * @remarks
- *
- * A preceding step like {@link When_I_find_element_by_label_text | "When I find element by label text"} is required. For example:
- *
- * ```gherkin
- * When I find element by label text "Input"
- *   And I clear
- * ```
- */
-export function When_I_clear() {
-  getCypressElement().clear();
-}
-
-When('I clear', When_I_clear);
-
-/**
  * When I type:
  *
  * ```gherkin
@@ -49,7 +15,7 @@ When('I clear', When_I_clear);
  * When I type "Hello, world!"
  * ```
  *
- * [Options](https://docs.cypress.io/api/commands/type#Arguments):
+ * With [options](https://docs.cypress.io/api/commands/type#Arguments):
  *
  * ```gherkin
  * When I type "Hello, world!"


### PR DESCRIPTION
## What is the motivation for this pull request?

Pass options to steps:

- "When I blur"
- "When I focus"
- "When I submit"
- "When I clear"
- "When I click"
- "When I click on button"
- "When I click on link"
- "When I click on text"
- "When I click on label"

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [x] Documentation