### PR TITLE
feat: pass options to action steps

### DIFF
--- a/src/actions/double-click.ts
+++ b/src/actions/double-click.ts
@@ -1,6 +1,6 @@
-import { When } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
 
-import { getCypressElement } from '../utils';
+import { getCypressElement, getOptions } from '../utils';
 
 /**
  * When I double-click:
@@ -19,6 +19,23 @@ import { getCypressElement } from '../utils';
  * When I double-click
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/dblclick#Arguments):
+ *
+ * ```gherkin
+ * When I double-click
+ *   | altKey | false |
+ *   | animationDistanceThreshold | 5 |
+ *   | ctrlKey | false |
+ *   | log | true |
+ *   | force | false |
+ *   | metaKey | false |
+ *   | multiple | false |
+ *   | scrollBehavior | top |
+ *   | shiftKey | false |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
+ * ```
+ *
  * @remarks
  *
  * A preceding step like {@link When_I_find_element_by_text | "When I find element by text"} is required. For example:
@@ -33,8 +50,8 @@ import { getCypressElement } from '../utils';
  * - {@link When_I_click | When I click}
  * - {@link When_I_right_click | When I right-click}
  */
-export function When_I_double_click() {
-  getCypressElement().dblclick();
+export function When_I_double_click(options?: DataTable) {
+  getCypressElement().dblclick(getOptions(options));
 }
 
 When('I double-click', When_I_double_click);

--- a/src/actions/double-click.ts
+++ b/src/actions/double-click.ts
@@ -73,13 +73,30 @@ When('I double-click', When_I_double_click);
  * When I double-click on text "Text"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/dblclick#Arguments):
+ *
+ * ```gherkin
+ * When I double-click on text "Text"
+ *   | altKey | false |
+ *   | animationDistanceThreshold | 5 |
+ *   | ctrlKey | false |
+ *   | log | true |
+ *   | force | false |
+ *   | metaKey | false |
+ *   | multiple | false |
+ *   | scrollBehavior | top |
+ *   | shiftKey | false |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
+ * ```
+ *
  * @see
  *
  * - {@link When_I_click_on_text | When I click on text}
  * - {@link When_I_right_click_on_text | When I right-click on text}
  */
-export function When_I_double_click_on_text(text: string) {
-  cy.contains(text).dblclick();
+export function When_I_double_click_on_text(text: string, options?: DataTable) {
+  cy.contains(text).dblclick(getOptions(options));
 }
 
 When('I double-click on text {string}', When_I_double_click_on_text);

--- a/src/actions/right-click.ts
+++ b/src/actions/right-click.ts
@@ -73,13 +73,30 @@ When('I right-click', When_I_right_click);
  * When I right-click on text "Text"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/rightclick#Arguments):
+ *
+ * ```gherkin
+ * When I right-click on text "Text"
+ *   | altKey | false |
+ *   | animationDistanceThreshold | 5 |
+ *   | ctrlKey | false |
+ *   | log | true |
+ *   | force | false |
+ *   | metaKey | false |
+ *   | multiple | false |
+ *   | scrollBehavior | top |
+ *   | shiftKey | false |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
+ * ```
+ *
  * @see
  *
  * - {@link When_I_click_on_text | When I click on text}
  * - {@link When_I_double_click_on_text | When I double-click on text}
  */
-export function When_I_right_click_on_text(text: string) {
-  cy.contains(text).rightclick();
+export function When_I_right_click_on_text(text: string, options?: DataTable) {
+  cy.contains(text).rightclick(getOptions(options));
 }
 
 When('I right-click on text {string}', When_I_right_click_on_text);

--- a/src/actions/right-click.ts
+++ b/src/actions/right-click.ts
@@ -1,6 +1,6 @@
-import { When } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
 
-import { getCypressElement } from '../utils';
+import { getCypressElement, getOptions } from '../utils';
 
 /**
  * When I right-click:
@@ -19,6 +19,23 @@ import { getCypressElement } from '../utils';
  * When I right-click
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/rightclick#Arguments):
+ *
+ * ```gherkin
+ * When I right-click
+ *   | altKey | false |
+ *   | animationDistanceThreshold | 5 |
+ *   | ctrlKey | false |
+ *   | log | true |
+ *   | force | false |
+ *   | metaKey | false |
+ *   | multiple | false |
+ *   | scrollBehavior | top |
+ *   | shiftKey | false |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
+ * ```
+ *
  * @remarks
  *
  * A preceding step like {@link When_I_find_element_by_text | "When I find element by text"} is required. For example:
@@ -33,8 +50,8 @@ import { getCypressElement } from '../utils';
  * - {@link When_I_click | When I click}
  * - {@link When_I_double_click | When I double-click}
  */
-export function When_I_right_click() {
-  getCypressElement().rightclick();
+export function When_I_right_click(options?: DataTable) {
+  getCypressElement().rightclick(getOptions(options));
 }
 
 When('I right-click', When_I_right_click);


### PR DESCRIPTION
## What is the motivation for this pull request?

Pass options to action steps:

- "When I right click"
- "When I right click on text"
- "When I double click"
- "When I double click on text"

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [x] Documentation