### PR TITLE
feat(actions): add "When I double click position"

### DIFF
--- a/cypress/e2e/cypress/example.feature
+++ b/cypress/e2e/cypress/example.feature
@@ -31,9 +31,15 @@ Feature: Cypress example
   Scenario: Double-click text
     Given I visit "https://example.cypress.io/commands/actions"
       And I double-click on text "Double click to edit"
+    Then I find input by display value "Double click to edit"
     When I reload the page
       And I find element by text "Double click to edit"
       And I double-click
+    Then I find input by display value "Double click to edit"
+    When I reload the page
+      And I find element by text "Double click to edit"
+      And I double-click "top"
+    Then I find input by display value "Double click to edit"
 
   Scenario: Right-click text
     Given I visit "https://example.cypress.io/commands/actions"

--- a/src/actions/double-click.ts
+++ b/src/actions/double-click.ts
@@ -1,6 +1,6 @@
 import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
 
-import { getCypressElement, getOptions } from '../utils';
+import { camelCase, getCypressElement, getOptions } from '../utils';
 
 /**
  * When I double-click:
@@ -11,6 +11,7 @@ import { getCypressElement, getOptions } from '../utils';
  *
  * Alternative:
  *
+ * - {@link When_I_double_click_position | When I double-click position}
  * - {@link When_I_double_click_on_text | When I double-click on text}
  *
  * @example
@@ -55,6 +56,86 @@ export function When_I_double_click(options?: DataTable) {
 }
 
 When('I double-click', When_I_double_click);
+
+/**
+ * When I double-click position:
+ *
+ * ```gherkin
+ * When I double-click {string}
+ * ```
+ *
+ * You can double-click on 9 specific positions of an element:
+ *
+ * ```
+ *  -------------------------------------
+ * | top-left        top       top-right |
+ * |                                     |
+ * |                                     |
+ * |                                     |
+ * | left          center          right |
+ * |                                     |
+ * |                                     |
+ * |                                     |
+ * | bottom-left   bottom   bottom-right |
+ *  -------------------------------------
+ * ```
+ *
+ * @example
+ *
+ * ```gherkin
+ * When I double-click "top-left"
+ * ```
+ *
+ * With [options](https://docs.cypress.io/api/commands/dblclick#Arguments):
+ *
+ * ```gherkin
+ * When I double-click "top"
+ *   | altKey | false |
+ *   | animationDistanceThreshold | 5 |
+ *   | ctrlKey | false |
+ *   | log | true |
+ *   | force | false |
+ *   | metaKey | false |
+ *   | multiple | false |
+ *   | scrollBehavior | top |
+ *   | shiftKey | false |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
+ * ```
+ *
+ * @remarks
+ *
+ * A preceding step like {@link When_I_find_element_by_text | "When I find element by text"} is required. For example:
+ *
+ * ```gherkin
+ * When I find element by text "Text"
+ *   And I double-click "top-right"
+ * ```
+ *
+ * @see
+ *
+ * - {@link When_I_double_click | When I double-click}
+ */
+export function When_I_double_click_position(
+  position:
+    | 'top'
+    | 'left'
+    | 'center'
+    | 'right'
+    | 'bottom'
+    | 'bottom-left'
+    | 'bottom-right'
+    | 'top-left'
+    | 'top-right',
+  options?: DataTable,
+) {
+  getCypressElement().dblclick(
+    camelCase(position) as Cypress.PositionType,
+    getOptions(options),
+  );
+}
+
+When('I double-click {string}', When_I_double_click_position);
 
 /**
  * When I double-click on text:


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(actions): add "When I double click position"

## What is the current behavior?

No way to double-click position

## What is the new behavior?

Able to double-click position:

```
 -------------------------------------
| top-left        top       top-right |
|                                     |
|                                     |
|                                     |
| left          center          right |
|                                     |
|                                     |
|                                     |
| bottom-left   bottom   bottom-right |
 -------------------------------------
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation