### PR TITLE
feat(actions): add "When I click x-y coordinates"

### DIFF
--- a/cypress/e2e/cypress/example.feature
+++ b/cypress/e2e/cypress/example.feature
@@ -154,6 +154,27 @@ Feature: Cypress example
       And I get element by selector "#scrollable-both button"
     Then I see element is visible
 
+  Scenario: Click position
+    Given I visit "https://example.cypress.io/commands/actions"
+    When I get element by selector "#action-canvas"
+      And I click "top-left"
+      And I click "top"
+      And I click "top-right"
+      And I click "left"
+      And I click "right"
+      And I click "bottom-left"
+      And I click "bottom"
+      And I click "bottom-right"
+    When I reload the page
+      And I get element by selector "#action-canvas"
+      And I click 80px and 75px
+      And I click 170px and 75px
+      And I click 80px and 165px
+      And I click 100px and 185px
+      And I click 125px and 190px
+      And I click 150px and 185px
+      And I click 170px and 165px
+
   Scenario: Get nth element
     Given I visit "https://example.cypress.io/commands/aliasing"
     When I find buttons by text "Change"

--- a/src/actions/click.ts
+++ b/src/actions/click.ts
@@ -15,8 +15,9 @@ import { camelCase, getCypressElement, getOptions } from '../utils';
  *
  * Alternative:
  *
- * - {@link When_I_click_position | When I click position}
  * - {@link When_I_click_on_text | When I click on text}
+ * - {@link When_I_click_position | When I click position}
+ * - {@link When_I_click_x_y_coordinates | When I click x-y coordinates}
  *
  * @example
  *
@@ -119,6 +120,7 @@ When('I click', When_I_click);
  * @see
  *
  * - {@link When_I_click | When I click}
+ * - {@link When_I_click_x_y_coordinates | When I click x-y coordinates}
  */
 export function When_I_click_position(
   position:
@@ -140,6 +142,60 @@ export function When_I_click_position(
 }
 
 When('I click {string}', When_I_click_position);
+
+/**
+ * When I click x-y coordinates:
+ *
+ * ```gherkin
+ * When I click {int}px and {int}px
+ * ```
+ *
+ * @example
+ *
+ * ```gherkin
+ * When I click 80px and 75px
+ * ```
+ *
+ * With [options](https://docs.cypress.io/api/commands/click#Arguments):
+ *
+ * ```gherkin
+ * When I click 80px and 75px
+ *   | altKey | false |
+ *   | animationDistanceThreshold | 5 |
+ *   | ctrlKey | false |
+ *   | log | true |
+ *   | force | false |
+ *   | metaKey | false |
+ *   | multiple | false |
+ *   | scrollBehavior | top |
+ *   | shiftKey | false |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
+ * ```
+ *
+ * @remarks
+ *
+ * A preceding step like {@link When_I_find_element_by_text | "When I find element by text"} is required. For example:
+ *
+ * ```gherkin
+ * When I find element by text "Text"
+ *     And I click 80px and 75px
+ * ```
+ *
+ * @see
+ *
+ * - {@link When_I_click | When I click}
+ * - {@link When_I_click_position | When I click position}
+ */
+export function When_I_click_x_y_coordinates(
+  x: number,
+  y: number,
+  options?: DataTable,
+) {
+  getCypressElement().click(x, y, getOptions(options));
+}
+
+When('I click {int}px and {int}px', When_I_click_x_y_coordinates);
 
 /**
  * When I click on button:


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(actions): add "When I click x-y coordinates"

## What is the current behavior?

No way to click x-y coordinates

## What is the new behavior?

Click x-y coordinates

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation