### PR TITLE
feat: add "Then I see element exists" and "Then I see element does not exist"

### DIFF
--- a/cypress/e2e/cypress/example.feature
+++ b/cypress/e2e/cypress/example.feature
@@ -21,6 +21,10 @@ Feature: Cypress example
       And I see button "Click to toggle popover"
     When I click on button "Click to toggle popover"
     Then I see text "This popover shows up on click"
+      And I find elements by role "tooltip"
+    When I click on text "Click to toggle popover"
+      And I wait 500 milliseconds
+    Then I see element does not exist
 
   Scenario: See, click, and type label
     Given I visit "https://example.cypress.io/commands/actions"
@@ -362,4 +366,6 @@ Feature: Cypress example
   Scenario: Role
     Given I visit "https://example.cypress.io/commands/querying"
     When I find elements by role "button"
-      And I find element by role "button"
+    Then I see element exists
+    When I find element by role "button"
+    Then I see element is visible

--- a/cypress/e2e/httpbin/httpbin.feature
+++ b/cypress/e2e/httpbin/httpbin.feature
@@ -1,0 +1,5 @@
+Feature: httpbin
+  Scenario: Loading spinner
+    Given I visit "https://httpbin.org/"
+    When I get element by selector ".loading"
+    Then I see element is not visible

--- a/src/assertions/exist.ts
+++ b/src/assertions/exist.ts
@@ -35,6 +35,7 @@ import { getCypressElement, getOptions } from '../utils';
  *
  * @see
  *
+ * - {@link Then_I_see_element_is_visible | Then I see element is visible}
  * - {@link Then_I_see_element_does_not_exist | Then I see element does not exist}
  */
 export function Then_I_see_element_exists(options?: DataTable) {
@@ -76,6 +77,7 @@ Then('I see element exists', Then_I_see_element_exists);
  *
  * @see
  *
+ * - {@link Then_I_see_element_is_not_visible | Then I see element is not visible}
  * - {@link Then_I_see_element_exists | Then I see element exists}
  */
 export function Then_I_see_element_does_not_exist(options?: DataTable) {

--- a/src/assertions/exist.ts
+++ b/src/assertions/exist.ts
@@ -1,0 +1,33 @@
+import { Then } from '@badeball/cypress-cucumber-preprocessor';
+
+import { getCypressElement } from '../utils';
+
+/**
+ * Then I see element exists:
+ *
+ * ```gherkin
+ * Then I see element exists
+ * ```
+ *
+ * Assert element **_exists_** in the screen.
+ *
+ * @example
+ *
+ * ```gherkin
+ * Then I see element exists
+ * ```
+ *
+ * @remarks
+ *
+ * A preceding step like {@link When_I_find_element_by_text | "When I find element by text"} is required. For example:
+ *
+ * ```gherkin
+ * When I find element by text "Text"
+ * Then I see element exists
+ * ```
+ */
+export function Then_I_see_element_exists() {
+  getCypressElement().should('exist');
+}
+
+Then('I see element exists', Then_I_see_element_exists);

--- a/src/assertions/exist.ts
+++ b/src/assertions/exist.ts
@@ -1,6 +1,6 @@
-import { Then } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, Then } from '@badeball/cypress-cucumber-preprocessor';
 
-import { getCypressElement } from '../utils';
+import { getCypressElement, getOptions } from '../utils';
 
 /**
  * Then I see element exists:
@@ -17,6 +17,13 @@ import { getCypressElement } from '../utils';
  * Then I see element exists
  * ```
  *
+ * With options:
+ *
+ * ```gherkin
+ * Then I see element exists
+ *   | timeout | 4000 |
+ * ```
+ *
  * @remarks
  *
  * A preceding step like {@link When_I_find_element_by_text | "When I find element by text"} is required. For example:
@@ -25,9 +32,54 @@ import { getCypressElement } from '../utils';
  * When I find element by text "Text"
  * Then I see element exists
  * ```
+ *
+ * @see
+ *
+ * - {@link Then_I_see_element_does_not_exist | Then I see element does not exist}
  */
-export function Then_I_see_element_exists() {
-  getCypressElement().should('exist');
+export function Then_I_see_element_exists(options?: DataTable) {
+  getCypressElement().should('exist', getOptions(options));
 }
 
 Then('I see element exists', Then_I_see_element_exists);
+
+/**
+ * Then I see element does not exist:
+ *
+ * ```gherkin
+ * Then I see element does not exist
+ * ```
+ *
+ * Assert element **_does not exist_** in the screen.
+ *
+ * @example
+ *
+ * ```gherkin
+ * Then I see element does not exist
+ * ```
+ *
+ * With options:
+ *
+ * ```gherkin
+ * Then I see element does not exist
+ *   | timeout | 4000 |
+ * ```
+ *
+ * @remarks
+ *
+ * A preceding step like {@link When_I_get_element_by_selector | "When I get element by selector"} is required. For example:
+ *
+ * ```gherkin
+ * When I get element by selector ".loading"
+ * Then I see element does not exist
+ * ```
+ *
+ * @see
+ *
+ * - {@link Then_I_see_element_exists | Then I see element exists}
+ */
+export function Then_I_see_element_does_not_exist(options?: DataTable) {
+  getCypressElement().should('not.exist', getOptions(options));
+}
+
+Then('I see element does not exist', Then_I_see_element_does_not_exist);

--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -3,6 +3,7 @@ export * from './button';
 export * from './cookie';
 export * from './count';
 export * from './document-title';
+export * from './exist';
 export * from './hash';
 export * from './heading';
 export * from './label';

--- a/src/assertions/visible.ts
+++ b/src/assertions/visible.ts
@@ -1,6 +1,6 @@
-import { Then } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, Then } from '@badeball/cypress-cucumber-preprocessor';
 
-import { getCypressElement } from '../utils';
+import { getCypressElement, getOptions } from '../utils';
 
 /**
  * Then I see element is visible:
@@ -9,10 +9,19 @@ import { getCypressElement } from '../utils';
  * Then I see element is visible
  * ```
  *
+ * Assert element **_is visible_** in the screen.
+ *
  * @example
  *
  * ```gherkin
  * Then I see element is visible
+ * ```
+ *
+ * With options:
+ *
+ * ```gherkin
+ * Then I see element is visible
+ *   | timeout | 4000 |
  * ```
  *
  * @remarks
@@ -29,8 +38,8 @@ import { getCypressElement } from '../utils';
  * - {@link Then_I_see_element_is_not_visible | Then I see element is not visible}
  * - {@link Then_I_see_text | Then I see text}
  */
-export function Then_I_see_element_is_visible() {
-  getCypressElement().should('be.visible');
+export function Then_I_see_element_is_visible(options?: DataTable) {
+  getCypressElement().should('be.visible', getOptions(options));
 }
 
 Then('I see element is visible', Then_I_see_element_is_visible);
@@ -42,10 +51,19 @@ Then('I see element is visible', Then_I_see_element_is_visible);
  * Then I see element is not visible
  * ```
  *
+ * Assert element **_is not visible_** in the screen.
+ *
  * @example
  *
  * ```gherkin
  * Then I see element is not visible
+ * ```
+ *
+ * With options:
+ *
+ * ```gherkin
+ * Then I see element is visible
+ *   | timeout | 4000 |
  * ```
  *
  * @remarks
@@ -61,10 +79,11 @@ Then('I see element is visible', Then_I_see_element_is_visible);
  *
  * - {@link Then_I_do_not_see_text | Then I do not see text}
  * - {@link Then_I_do_not_see_visible_text | Then I do not see visible text}
+ * - {@link Then_I_see_element_does_not_exist | Then I see element does not exist}
  * - {@link Then_I_see_element_is_visible | Then I see element is visible}
  */
-export function Then_I_see_element_is_not_visible() {
-  getCypressElement().should('not.be.visible');
+export function Then_I_see_element_is_not_visible(options?: DataTable) {
+  getCypressElement().should('not.be.visible', getOptions(options));
 }
 
 Then('I see element is not visible', Then_I_see_element_is_not_visible);

--- a/src/queries/get.ts
+++ b/src/queries/get.ts
@@ -1,6 +1,6 @@
-import { When } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
 
-import { setCypressElement } from '../utils';
+import { getCypressElement, getOptions, setCypressElement } from '../utils';
 
 /**
  * When I get element by selector:
@@ -19,13 +19,27 @@ import { setCypressElement } from '../utils';
  * When I get element by selector ".list > li"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/get#Arguments):
+ *
+ * ```gherkin
+ * When I get element by selector ".dropdown-menu"
+ *   | log | true |
+ *   | timeout | 4000 |
+ *   | withinSubject | null |
+ *   | includeShadowDom | false |
+ * ```
+ *
  * @see
  *
  * - {@link When_I_get_elements_by_selector | When I get elements by selector}
  * - {@link When_I_find_element_by_selector | When I find element by selector}
  */
-export function When_I_get_element_by_selector(selector: string) {
-  setCypressElement(cy.get(selector).first());
+export function When_I_get_element_by_selector(
+  selector: string,
+  options?: DataTable,
+) {
+  When_I_get_elements_by_selector(selector, options);
+  setCypressElement(getCypressElement().first());
 }
 
 When('I get element by selector {string}', When_I_get_element_by_selector);
@@ -47,12 +61,25 @@ When('I get element by selector {string}', When_I_get_element_by_selector);
  * When I get elements by selector ".list > li"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/get#Arguments):
+ *
+ * ```gherkin
+ * When I get element by selector ".dropdown-menu"
+ *   | log | true |
+ *   | timeout | 4000 |
+ *   | withinSubject | null |
+ *   | includeShadowDom | false |
+ * ```
+ *
  * @see
  *
  * - {@link When_I_get_element_by_selector | When I get element by selector}
  */
-export function When_I_get_elements_by_selector(selector: string) {
-  setCypressElement(cy.get(selector));
+export function When_I_get_elements_by_selector(
+  selector: string,
+  options?: DataTable,
+) {
+  setCypressElement(cy.get(selector, getOptions(options)));
 }
 
 When('I get elements by selector {string}', When_I_get_elements_by_selector);


### PR DESCRIPTION
## What is the motivation for this pull request?

Add steps:

- "Then I see element exists"
- "Then I see element does not exist"

Pass options:

- "Then I see element is visible"
- "Then I see element is not visible"
- "When I get elements by selector"
- "When I get element by selector"

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation