### PR TITLE
feat: pass options to label steps

### DIFF
--- a/src/actions/click.ts
+++ b/src/actions/click.ts
@@ -212,21 +212,14 @@ When('I click {int}px and {int}px', When_I_click_x_y_coordinates);
  * When I click on button "Button"
  * ```
  *
- * With [options](https://docs.cypress.io/api/commands/click#Arguments):
+ * With [options](https://docs.cypress.io/api/commands/get#Arguments):
  *
  * ```gherkin
  * When I click on button "Button"
- *   | altKey | false |
- *   | animationDistanceThreshold | 5 |
- *   | ctrlKey | false |
  *   | log | true |
- *   | force | false |
- *   | metaKey | false |
- *   | multiple | false |
- *   | scrollBehavior | top |
- *   | shiftKey | false |
  *   | timeout | 4000 |
- *   | waitForAnimations | true |
+ *   | withinSubject | null |
+ *   | includeShadowDom | false |
  * ```
  *
  * @see
@@ -234,8 +227,8 @@ When('I click {int}px and {int}px', When_I_click_x_y_coordinates);
  * - {@link When_I_click_on_text | When I click on text}
  */
 export function When_I_click_on_button(text: string, options?: DataTable) {
-  When_I_find_button_by_text(text);
-  getCypressElement().click(getOptions(options));
+  When_I_find_button_by_text(text, options);
+  getCypressElement().click();
 }
 
 When('I click on button {string}', When_I_click_on_button);
@@ -255,21 +248,14 @@ When('I click on button {string}', When_I_click_on_button);
  * When I click on link "Link"
  * ```
  *
- * With [options](https://docs.cypress.io/api/commands/click#Arguments):
+ * With [options](https://docs.cypress.io/api/commands/contains#Arguments):
  *
  * ```gherkin
  * When I click on link "Link"
- *   | altKey | false |
- *   | animationDistanceThreshold | 5 |
- *   | ctrlKey | false |
+ *   | matchCase | true |
  *   | log | true |
- *   | force | false |
- *   | metaKey | false |
- *   | multiple | false |
- *   | scrollBehavior | top |
- *   | shiftKey | false |
  *   | timeout | 4000 |
- *   | waitForAnimations | true |
+ *   | includeShadowDom | false |
  * ```
  *
  * @see
@@ -277,7 +263,7 @@ When('I click on button {string}', When_I_click_on_button);
  * - {@link When_I_click_on_text | When I click on text}
  */
 export function When_I_click_on_link(text: string, options?: DataTable) {
-  cy.contains('a', text).first().click(getOptions(options));
+  cy.contains('a', text, getOptions(options)).first().click();
 }
 
 When('I click on link {string}', When_I_click_on_link);
@@ -299,21 +285,14 @@ When('I click on link {string}', When_I_click_on_link);
  * When I click on text "Text"
  * ```
  *
- * With [options](https://docs.cypress.io/api/commands/click#Arguments):
+ * With [options](https://docs.cypress.io/api/commands/contains#Arguments):
  *
  * ```gherkin
  * When I click on text "Text"
- *   | altKey | false |
- *   | animationDistanceThreshold | 5 |
- *   | ctrlKey | false |
+ *   | matchCase | true |
  *   | log | true |
- *   | force | false |
- *   | metaKey | false |
- *   | multiple | false |
- *   | scrollBehavior | top |
- *   | shiftKey | false |
  *   | timeout | 4000 |
- *   | waitForAnimations | true |
+ *   | includeShadowDom | false |
  * ```
  *
  * @see
@@ -323,7 +302,7 @@ When('I click on link {string}', When_I_click_on_link);
  * - {@link When_I_click_on_link | When I click on link}
  */
 export function When_I_click_on_text(text: string, options?: DataTable) {
-  cy.contains(text).click(getOptions(options));
+  cy.contains(text, getOptions(options)).click();
 }
 
 When('I click on text {string}', When_I_click_on_text);
@@ -341,21 +320,14 @@ When('I click on text {string}', When_I_click_on_text);
  * When I click on label "Label"
  * ```
  *
- * With [options](https://docs.cypress.io/api/commands/click#Arguments):
+ * With [options](https://docs.cypress.io/api/commands/get#Arguments):
  *
  * ```gherkin
  * When I click on label "Label"
- *   | altKey | false |
- *   | animationDistanceThreshold | 5 |
- *   | ctrlKey | false |
  *   | log | true |
- *   | force | false |
- *   | metaKey | false |
- *   | multiple | false |
- *   | scrollBehavior | top |
- *   | shiftKey | false |
  *   | timeout | 4000 |
- *   | waitForAnimations | true |
+ *   | withinSubject | null |
+ *   | includeShadowDom | false |
  * ```
  *
  * @see
@@ -363,8 +335,8 @@ When('I click on text {string}', When_I_click_on_text);
  * - {@link When_I_click_on_text | When I click on text}
  */
 export function When_I_click_on_label(text: string, options?: DataTable) {
-  When_I_find_element_by_label_text(text);
-  getCypressElement().click(getOptions(options));
+  When_I_find_element_by_label_text(text, options);
+  getCypressElement().click();
 }
 
 When('I click on label {string}', When_I_click_on_label);

--- a/src/assertions/label.ts
+++ b/src/assertions/label.ts
@@ -1,4 +1,4 @@
-import { Then } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, Then } from '@badeball/cypress-cucumber-preprocessor';
 
 import { When_I_find_elements_by_label_text } from '../queries';
 import { getCypressElement } from '../utils';
@@ -18,12 +18,22 @@ import { getCypressElement } from '../utils';
  * Then I see label "Label"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/get#Arguments):
+ *
+ * ```gherkin
+ * Then I see label "Label"
+ *   | log | true |
+ *   | timeout | 4000 |
+ *   | withinSubject | null |
+ *   | includeShadowDom | false |
+ * ```
+ *
  * @see
  *
  * - {@link Then_I_see_text | Then I see text}
  */
-export function Then_I_see_label(text: string) {
-  When_I_find_elements_by_label_text(text);
+export function Then_I_see_label(text: string, options?: DataTable) {
+  When_I_find_elements_by_label_text(text, options);
   getCypressElement().should('exist');
 }
 
@@ -44,12 +54,22 @@ Then('I see label {string}', Then_I_see_label);
  * Then I do not see label "Label"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/get#Arguments):
+ *
+ * ```gherkin
+ * Then I do not see label "Label"
+ *   | log | true |
+ *   | timeout | 4000 |
+ *   | withinSubject | null |
+ *   | includeShadowDom | false |
+ * ```
+ *
  * @see
  *
  * - {@link Then_I_do_not_see_text | Then I do not see text}
  */
-export function Then_I_do_not_see_label(text: string) {
-  When_I_find_elements_by_label_text(text);
+export function Then_I_do_not_see_label(text: string, options?: DataTable) {
+  When_I_find_elements_by_label_text(text, options);
   getCypressElement().should('not.exist');
 }
 

--- a/src/queries/label.ts
+++ b/src/queries/label.ts
@@ -1,6 +1,6 @@
-import { When } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
 
-import { getCypressElement, setCypressElement } from '../utils';
+import { getCypressElement, getOptions, setCypressElement } from '../utils';
 
 /**
  * When I find elements by label text:
@@ -9,12 +9,22 @@ import { getCypressElement, setCypressElement } from '../utils';
  * When I find elements by label text {string}
  * ```
  *
- * Finds all visible `label`, `aria-labelledby`, or `aria-label` that matches the text.
+ * Find all visible `label`, `aria-labelledby`, or `aria-label` that matches the text.
  *
  * @example
  *
  * ```gherkin
  * When I find elements by label text "Email"
+ * ```
+ *
+ * With [options](https://docs.cypress.io/api/commands/get#Arguments):
+ *
+ * ```gherkin
+ * When I find elements by label text "Email"
+ *   | log | true |
+ *   | timeout | 4000 |
+ *   | withinSubject | null |
+ *   | includeShadowDom | false |
  * ```
  *
  * @remarks
@@ -33,14 +43,17 @@ import { getCypressElement, setCypressElement } from '../utils';
  *
  * - {@link When_I_find_element_by_label_text | When I find element by label text }
  */
-export function When_I_find_elements_by_label_text(text: string) {
+export function When_I_find_elements_by_label_text(
+  text: string,
+  options?: DataTable,
+) {
   const selectors = [
     `label:contains(${JSON.stringify(text)})`,
     `[aria-labelledby=${JSON.stringify(text)}]`,
     `[aria-label=${JSON.stringify(text)}]`,
   ].map((selector) => `${selector}:visible`);
 
-  setCypressElement(cy.get(selectors.join(',')));
+  setCypressElement(cy.get(selectors.join(','), getOptions(options)));
 }
 
 When(
@@ -55,12 +68,22 @@ When(
  * When I find element by label text {string}
  * ```
  *
- * Finds the first visible `label`, `aria-labelledby`, or `aria-label` that matches the text.
+ * Find the first visible `label`, `aria-labelledby`, or `aria-label` that matches the text.
  *
  * @example
  *
  * ```gherkin
  * When I find element by label text "Email"
+ * ```
+ *
+ * With [options](https://docs.cypress.io/api/commands/get#Arguments):
+ *
+ * ```gherkin
+ * When I find element by label text "Email"
+ *   | log | true |
+ *   | timeout | 4000 |
+ *   | withinSubject | null |
+ *   | includeShadowDom | false |
  * ```
  *
  * @remarks
@@ -78,8 +101,11 @@ When(
  *
  * - {@link When_I_find_elements_by_label_text | When I find elements by label text }
  */
-export function When_I_find_element_by_label_text(text: string) {
-  When_I_find_elements_by_label_text(text);
+export function When_I_find_element_by_label_text(
+  text: string,
+  options?: DataTable,
+) {
+  When_I_find_elements_by_label_text(text, options);
   setCypressElement(getCypressElement().first());
 }
 


### PR DESCRIPTION
## What is the motivation for this pull request?

Pass options to:

- "When I find elements by label text"
- "When I find element by label text"
- "Then I see label"
- "Then I do not see label"

Fix options in click steps

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [x] Documentation