### PR TITLE
feat: pass options to heading steps

### DIFF
--- a/src/assertions/heading.ts
+++ b/src/assertions/heading.ts
@@ -54,12 +54,22 @@ Then('I see heading {string}', Then_I_see_heading);
  * Then I do not see heading "Heading"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/get#Arguments):
+ *
+ * ```gherkin
+ * Then I do not see heading "Heading"
+ *   | log | true |
+ *   | timeout | 4000 |
+ *   | withinSubject | null |
+ *   | includeShadowDom | false |
+ * ```
+ *
  * @see
  *
  * - {@link Then_I_do_not_see_text | Then I do not see text}
  */
-export function Then_I_do_not_see_heading(text: string) {
-  When_I_find_headings_by_text(text);
+export function Then_I_do_not_see_heading(text: string, options?: DataTable) {
+  When_I_find_headings_by_text(text, options);
   getCypressElement().should('not.exist');
 }
 

--- a/src/assertions/heading.ts
+++ b/src/assertions/heading.ts
@@ -1,4 +1,4 @@
-import { Then } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, Then } from '@badeball/cypress-cucumber-preprocessor';
 
 import { When_I_find_headings_by_text } from '../queries';
 import { getCypressElement } from '../utils';
@@ -18,12 +18,22 @@ import { getCypressElement } from '../utils';
  * Then I see heading "Heading"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/get#Arguments):
+ *
+ * ```gherkin
+ * Then I see heading "Heading"
+ *   | log | true |
+ *   | timeout | 4000 |
+ *   | withinSubject | null |
+ *   | includeShadowDom | false |
+ * ```
+ *
  * @see
  *
  * - {@link Then_I_see_text | Then I see text}
  */
-export function Then_I_see_heading(text: string) {
-  When_I_find_headings_by_text(text);
+export function Then_I_see_heading(text: string, options?: DataTable) {
+  When_I_find_headings_by_text(text, options);
   getCypressElement().should('exist');
 }
 

--- a/src/queries/heading.ts
+++ b/src/queries/heading.ts
@@ -66,6 +66,16 @@ When('I find headings by text {string}', When_I_find_headings_by_text);
  * When I find heading by text "Heading"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/get#Arguments):
+ *
+ * ```gherkin
+ * When I find heading by text "Heading"
+ *   | log | true |
+ *   | timeout | 4000 |
+ *   | withinSubject | null |
+ *   | includeShadowDom | false |
+ * ```
+ *
  * @remarks
  *
  * This precedes steps like {@link When_I_click | "When I click"}. For example:
@@ -79,8 +89,8 @@ When('I find headings by text {string}', When_I_find_headings_by_text);
  *
  * - {@link When_I_find_headings_by_text | When I find headings by text}
  */
-export function When_I_find_heading_by_text(text: string) {
-  When_I_find_headings_by_text(text);
+export function When_I_find_heading_by_text(text: string, options?: DataTable) {
+  When_I_find_headings_by_text(text, options);
   setCypressElement(getCypressElement().first());
 }
 

--- a/src/queries/heading.ts
+++ b/src/queries/heading.ts
@@ -1,6 +1,6 @@
-import { When } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
 
-import { getCypressElement, setCypressElement } from '../utils';
+import { getCypressElement, getOptions, setCypressElement } from '../utils';
 
 /**
  * When I find headings by text:
@@ -13,6 +13,16 @@ import { getCypressElement, setCypressElement } from '../utils';
  *
  * ```gherkin
  * When I find headings by text "Heading"
+ * ```
+ *
+ * With [options](https://docs.cypress.io/api/commands/get#Arguments):
+ *
+ * ```gherkin
+ * When I find headings by text "Heading"
+ *   | log | true |
+ *   | timeout | 4000 |
+ *   | withinSubject | null |
+ *   | includeShadowDom | false |
  * ```
  *
  * @remarks
@@ -29,11 +39,14 @@ import { getCypressElement, setCypressElement } from '../utils';
  *
  * - {@link When_I_find_heading_by_text | When I find heading by text}
  */
-export function When_I_find_headings_by_text(text: string) {
+export function When_I_find_headings_by_text(
+  text: string,
+  options?: DataTable,
+) {
   const selector = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
     .map((tag) => `${tag}:contains(${JSON.stringify(text)}):visible`)
     .join(',');
-  setCypressElement(cy.get(selector));
+  setCypressElement(cy.get(selector, getOptions(options)));
 }
 
 When('I find headings by text {string}', When_I_find_headings_by_text);


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: pass options to heading steps

- "When I find headings by text"
- "When I find heading by text"
- "Then I see heading"
- "Then I do not see heading"

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [x] Documentation