### PR TITLE
feat(actions): pass click options to "When I click on button", "When I click on link", "When I click on text", "When I click on label"

### DIFF
--- a/cypress/e2e/cypress/example.feature
+++ b/cypress/e2e/cypress/example.feature
@@ -32,6 +32,15 @@ Feature: Cypress example
     When I click on label "Email address"
       And I type "test@example.com"
 
+  Scenario: Force click
+    Given I visit "https://example.cypress.io/commands/actions"
+    Then I click on button "I'm being covered"
+      | force | true |
+    When I reload the page
+      And I find button by text "I'm being covered"
+    Then I click
+      | force | true |
+
   Scenario: Double-click
     Given I visit "https://example.cypress.io/commands/actions"
       And I double-click on text "Double click to edit"

--- a/src/actions/click.ts
+++ b/src/actions/click.ts
@@ -262,14 +262,23 @@ When('I click on button {string}', When_I_click_on_button);
  * When I click on link "Link"
  * ```
  *
- * With [options](https://docs.cypress.io/api/commands/contains#Arguments):
+ * With options:
  *
  * ```gherkin
  * When I click on link "Link"
- *   | matchCase | true |
- *   | log | true |
- *   | timeout | 4000 |
+ *   | altKey | false |
+ *   | animationDistanceThreshold | 5 |
+ *   | ctrlKey | false |
+ *   | force | false |
  *   | includeShadowDom | false |
+ *   | log | true |
+ *   | metaKey | false |
+ *   | multiple | false |
+ *   | scrollBehavior | top |
+ *   | shiftKey | false |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
+ *   | withinSubject | null |
  * ```
  *
  * @see
@@ -277,7 +286,9 @@ When('I click on button {string}', When_I_click_on_button);
  * - {@link When_I_click_on_text | When I click on text}
  */
 export function When_I_click_on_link(text: string, options?: DataTable) {
-  getLinkElements(text, PseudoSelector.visible, options).first().click();
+  getLinkElements(text, PseudoSelector.visible, options)
+    .first()
+    .click(getOptions(options));
 }
 
 When('I click on link {string}', When_I_click_on_link);

--- a/src/actions/click.ts
+++ b/src/actions/click.ts
@@ -310,14 +310,23 @@ When('I click on link {string}', When_I_click_on_link);
  * When I click on text "Text"
  * ```
  *
- * With [options](https://docs.cypress.io/api/commands/contains#Arguments):
+ * With options:
  *
  * ```gherkin
  * When I click on text "Text"
- *   | matchCase | true |
- *   | log | true |
- *   | timeout | 4000 |
+ *   | altKey | false |
+ *   | animationDistanceThreshold | 5 |
+ *   | ctrlKey | false |
+ *   | force | false |
  *   | includeShadowDom | false |
+ *   | log | true |
+ *   | matchCase | true |
+ *   | metaKey | false |
+ *   | multiple | false |
+ *   | scrollBehavior | top |
+ *   | shiftKey | false |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
  * ```
  *
  * @see
@@ -327,7 +336,8 @@ When('I click on link {string}', When_I_click_on_link);
  * - {@link When_I_click_on_link | When I click on link}
  */
 export function When_I_click_on_text(text: string, options?: DataTable) {
-  cy.contains(text, getOptions(options)).click();
+  const opts = getOptions(options);
+  cy.contains(text, opts).click(opts);
 }
 
 When('I click on text {string}', When_I_click_on_text);

--- a/src/actions/click.ts
+++ b/src/actions/click.ts
@@ -355,14 +355,23 @@ When('I click on text {string}', When_I_click_on_text);
  * When I click on label "Label"
  * ```
  *
- * With [options](https://docs.cypress.io/api/commands/get#Arguments):
+ * With options:
  *
  * ```gherkin
  * When I click on label "Label"
- *   | log | true |
- *   | timeout | 4000 |
- *   | withinSubject | null |
+ *   | altKey | false |
+ *   | animationDistanceThreshold | 5 |
+ *   | ctrlKey | false |
+ *   | force | false |
  *   | includeShadowDom | false |
+ *   | log | true |
+ *   | metaKey | false |
+ *   | multiple | false |
+ *   | scrollBehavior | top |
+ *   | shiftKey | false |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
+ *   | withinSubject | null |
  * ```
  *
  * @see
@@ -371,7 +380,7 @@ When('I click on text {string}', When_I_click_on_text);
  */
 export function When_I_click_on_label(text: string, options?: DataTable) {
   When_I_find_element_by_label_text(text, options);
-  getCypressElement().click();
+  getCypressElement().click(getOptions(options));
 }
 
 When('I click on label {string}', When_I_click_on_label);

--- a/src/actions/click.ts
+++ b/src/actions/click.ts
@@ -216,14 +216,23 @@ When('I click {int}px and {int}px', When_I_click_x_y_coordinates);
  * When I click on button "Button"
  * ```
  *
- * With [options](https://docs.cypress.io/api/commands/get#Arguments):
+ * With options:
  *
  * ```gherkin
  * When I click on button "Button"
- *   | log | true |
- *   | timeout | 4000 |
- *   | withinSubject | null |
+ *   | altKey | false |
+ *   | animationDistanceThreshold | 5 |
+ *   | ctrlKey | false |
+ *   | force | false |
  *   | includeShadowDom | false |
+ *   | log | true |
+ *   | metaKey | false |
+ *   | multiple | false |
+ *   | scrollBehavior | top |
+ *   | shiftKey | false |
+ *   | timeout | 4000 |
+ *   | waitForAnimations | true |
+ *   | withinSubject | null |
  * ```
  *
  * @see
@@ -231,7 +240,9 @@ When('I click {int}px and {int}px', When_I_click_x_y_coordinates);
  * - {@link When_I_click_on_text | When I click on text}
  */
 export function When_I_click_on_button(text: string, options?: DataTable) {
-  getButtonElements(text, PseudoSelector.visible, options).first().click();
+  getButtonElements(text, PseudoSelector.visible, options)
+    .first()
+    .click(getOptions(options));
 }
 
 When('I click on button {string}', When_I_click_on_button);


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(actions): pass click options to

- "When I click on button"
- "When I click on link"
- "When I click on text"
- "When I click on label"

## What is the current behavior?

Options only passed to `get()`

## What is the new behavior?

Options passed to both `get()` and `click()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation