### PR TITLE
feat(actions): add "When I set Cypress config"

### DIFF
--- a/cypress/e2e/example/example.feature
+++ b/cypress/e2e/example/example.feature
@@ -67,4 +67,8 @@ Feature: Example
   Scenario: Get selector
     Given I visit "https://example.com/"
     When I get element by selector "p"
-    Then I count 1 element
+
+  Scenario: Cypress config
+    When I set Cypress config "defaultCommandTimeout" to "10000"
+      And I set Cypress config
+        | defaultCommandTimeout | 10000 |

--- a/src/actions/config.ts
+++ b/src/actions/config.ts
@@ -1,4 +1,6 @@
-import { When } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, When } from '@badeball/cypress-cucumber-preprocessor';
+
+import { getOptions } from '../utils';
 
 /**
  * When I set Cypress config:
@@ -13,6 +15,13 @@ import { When } from '@badeball/cypress-cucumber-preprocessor';
  *
  * ```gherkin
  * When I set Cypress config "defaultCommandTimeout" to "10000"
+ * ```
+ *
+ * Set multiple configuration options:
+ *
+ * ```gherkin
+ * When I set Cypress config
+ *   | defaultCommandTimeout | 10000 |
  * ```
  *
  * @remarks
@@ -31,6 +40,12 @@ export function When_I_set_Cypress_config(
   name: keyof Cypress.TestConfigOverrides,
   value: string,
 ) {
+  if ((name as unknown) instanceof DataTable) {
+    const options = getOptions(name as unknown as DataTable);
+    Cypress.config(options as Cypress.TestConfigOverrides);
+    return;
+  }
+
   switch (value) {
     case 'true':
       Cypress.config(name, true);
@@ -54,4 +69,5 @@ export function When_I_set_Cypress_config(
   }
 }
 
+When('I set Cypress config', When_I_set_Cypress_config);
 When('I set Cypress config {string} to {string}', When_I_set_Cypress_config);


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(actions): add "When I set Cypress config"

https://docs.cypress.io/api/cypress-api/config

## What is the current behavior?

Cypress config can be set 1 key-value pair at a time

## What is the new behavior?

Cypress config can be set via DataTable

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation