### PR TITLE
feat(assertions): pass options to hash steps

### DIFF
--- a/src/assertions/location/hash.ts
+++ b/src/assertions/location/hash.ts
@@ -1,4 +1,6 @@
-import { Then } from '@badeball/cypress-cucumber-preprocessor';
+import { DataTable, Then } from '@badeball/cypress-cucumber-preprocessor';
+
+import { getOptions } from '../../utils';
 
 /**
  * Then I see hash:
@@ -13,6 +15,14 @@ import { Then } from '@badeball/cypress-cucumber-preprocessor';
  * Then I see hash "#hash"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/hash#Arguments):
+ *
+ * ```gherkin
+ * Then I see hash "#hash"
+ *   | log | true |
+ *   | timeout | 4000 |
+ * ```
+ *
  * @remarks
  *
  * The URL hash includes the `#` character.
@@ -21,8 +31,8 @@ import { Then } from '@badeball/cypress-cucumber-preprocessor';
  *
  * - {@link Then_I_see_hash_contains | Then I see hash contains}
  */
-export function Then_I_see_hash(hash: string) {
-  cy.hash().should('equal', hash);
+export function Then_I_see_hash(hash: string, options?: DataTable) {
+  cy.hash(getOptions(options)).should('equal', hash);
 }
 
 Then('I see hash {string}', Then_I_see_hash);
@@ -40,12 +50,20 @@ Then('I see hash {string}', Then_I_see_hash);
  * Then I see hash contains "hash"
  * ```
  *
+ * With [options](https://docs.cypress.io/api/commands/hash#Arguments):
+ *
+ * ```gherkin
+ * Then I see hash contains "hash"
+ *   | log | true |
+ *   | timeout | 4000 |
+ * ```
+ *
  * @see
  *
  * - {@link Then_I_see_hash | Then I see hash}
  */
-export function Then_I_see_hash_contains(hash: string) {
-  cy.hash().should('contain', hash);
+export function Then_I_see_hash_contains(hash: string, options?: DataTable) {
+  cy.hash(getOptions(options)).should('contain', hash);
 }
 
 Then('I see hash contains {string}', Then_I_see_hash_contains);


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(assertions): pass options to hash steps

1. Then I see hash
2. Then I see hash contains

https://docs.cypress.io/api/commands/hash#Arguments

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [x] Documentation