### PR TITLE
ci(github): use `remarkablemark/find-and-split` in cypress.yml

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -10,30 +10,27 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        shard: [0, 1, 2]
+        shard: [1/3, 2/3, 3/3]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Split specs
+      - name: Find and split specs
+        uses: remarkablemark/find-and-split@v1
         id: specs
-        run: |
-          SPECS=specs
-          find cypress/e2e -type f -name '*.feature' > $SPECS
-          SPECS_COUNT=$(wc -l < $SPECS)
-          LINES=$(( ($SPECS_COUNT + 1) / ${{ strategy.job-total }} ))
-          split -d -l $LINES $SPECS spec
-          echo "SPECS<<EOF" >> $GITHUB_OUTPUT
-          cat spec0${{ matrix.shard }} >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+        with:
+          chunk: ${{ matrix.shard }}
+          delimiter: '\n'
+          directory: 'cypress/e2e'
+          pattern: '*.feature'
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
           browser: chrome
           spec: |
-            ${{ steps.specs.outputs.SPECS }}
+            ${{ steps.specs.outputs.files }}
 
       - name: Record failed screenshots
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What is the motivation for this pull request?

ci(github): use [`remarkablemark/find-and-split`](https://github.com/remarkablemark/find-and-split) in cypress.yml

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation